### PR TITLE
Fix number formatter precision for large values

### DIFF
--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -37,6 +37,11 @@ describe("formatNumberString", () => {
     expect(formatNumberString("1234567890")).toBe("1,234,567,890");
   });
 
+  it("handles extremely large numbers without losing precision", () => {
+    const bigNum = "12345678901234567890";
+    expect(formatNumberString(bigNum)).toBe("12,345,678,901,234,567,890");
+  });
+
   it("returns default display for invalid input", () => {
     expect(formatNumberString("not-a-number")).toBe("N/A");
   });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -13,12 +13,15 @@ export function formatNumberString(
   if (!numStr) return defaultDisplay;
 
   try {
-    // Parse the number string
-    const num = parseFloat(numStr);
-    if (isNaN(num)) return defaultDisplay;
+    // Remove any existing commas and validate the string contains only digits
+    // and an optional decimal part. This avoids precision issues with
+    // `parseFloat` on very large numbers.
+    const cleaned = String(numStr).replace(/,/g, "");
+    if (!/^\d+(\.\d+)?$/.test(cleaned)) return defaultDisplay;
 
-    // Format with commas for thousands separator
-    return num.toLocaleString();
+    const [intPart, decPart] = cleaned.split(".");
+    const withCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    return decPart ? `${withCommas}.${decPart}` : withCommas;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (error) {
     return defaultDisplay;


### PR DESCRIPTION
## Summary
- preserve large-number precision in `formatNumberString`
- test very large numeric strings

## Testing
- `npm test --silent`