### PR TITLE
Refactor rune name handling

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,9 @@ import type { Config } from "jest";
 const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node", // Assuming node environment for now, can be changed later if needed for UI tests
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
 };
 
 export default config;

--- a/src/app/api/ordiscan/rune-info/route.ts
+++ b/src/app/api/ordiscan/rune-info/route.ts
@@ -6,6 +6,7 @@ import {
   validateRequest,
 } from "@/lib/apiUtils";
 import { getRuneData } from "@/lib/runesData";
+import { normalizeRuneName } from "@/utils/runeUtils";
 import { z } from "zod";
 
 export async function GET(request: NextRequest) {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
   const { name: validName } = validation.data;
 
   // Ensure name doesn't have spacers for the API call
-  const formattedName = validName.replace(/•/g, "");
+  const formattedName = normalizeRuneName(validName);
 
   try {
     const runeInfo = await getRuneData(formattedName);

--- a/src/app/api/ordiscan/rune-market/route.ts
+++ b/src/app/api/ordiscan/rune-market/route.ts
@@ -6,6 +6,7 @@ import {
   validateRequest,
 } from "@/lib/apiUtils";
 import { getRuneMarketData } from "@/lib/runeMarketData";
+import { normalizeRuneName } from "@/utils/runeUtils";
 import { z } from "zod";
 
 export async function GET(request: NextRequest) {
@@ -19,7 +20,7 @@ export async function GET(request: NextRequest) {
   const { name: validName } = validation.data;
 
   // Ensure name doesn't have spacers for the API call
-  const formattedName = validName.replace(/•/g, "");
+  const formattedName = normalizeRuneName(validName);
 
   try {
     const marketInfo = await getRuneMarketData(formattedName);

--- a/src/app/api/rune-price-history/route.ts
+++ b/src/app/api/rune-price-history/route.ts
@@ -4,6 +4,7 @@ import {
   createErrorResponse,
   validateRequest,
 } from "@/lib/apiUtils";
+import { normalizeRuneName } from "@/utils/runeUtils";
 import { z } from "zod";
 
 // Define the schema for the query parameters
@@ -43,7 +44,7 @@ export async function GET(request: NextRequest) {
 
     // Format the rune name for the API call
     // Try with different formats to ensure we get data
-    const formattedSlug = originalSlug.replace(/[•.]/g, "").toUpperCase();
+    const formattedSlug = normalizeRuneName(originalSlug).toUpperCase();
 
     // Define a mapping for known runes that might have formatting issues
     const knownRunes: Record<string, string> = {

--- a/src/components/BorrowTab.tsx
+++ b/src/components/BorrowTab.tsx
@@ -24,6 +24,7 @@ import {
   LiquidiumPrepareBorrowResponse,
   LiquidiumSubmitBorrowResponse,
 } from "@/lib/apiClient";
+import { normalizeRuneName } from "@/utils/runeUtils";
 import {
   type RuneBalance as OrdiscanRuneBalance,
   type RuneMarketInfo as OrdiscanRuneMarketInfo,
@@ -120,8 +121,8 @@ export function BorrowTab({
             .filter(
               (rune) =>
                 rune.id !== liquidiumToken.id &&
-                rune.name.replace(/•/g, "") !==
-                  liquidiumToken.name.replace(/•/g, ""),
+                normalizeRuneName(rune.name) !==
+                  normalizeRuneName(liquidiumToken.name),
             );
           mappedRunes = [liquidiumToken, ...fetchedRunes];
         }
@@ -273,7 +274,7 @@ export function BorrowTab({
     runeName: string | undefined,
   ): string | null => {
     if (!runeName || !runeBalances) return null;
-    const formattedRuneName = runeName.replace(/•/g, "");
+    const formattedRuneName = normalizeRuneName(runeName);
     const found = runeBalances.find((rb) => rb.name === formattedRuneName);
     return found ? found.balance : "0";
   };

--- a/src/components/SwapTab.tsx
+++ b/src/components/SwapTab.tsx
@@ -18,6 +18,7 @@ import {
   type GetPSBTParams,
   type ConfirmPSBTParams,
 } from "satsterminal-sdk";
+import { normalizeRuneName } from "@/utils/runeUtils";
 import { Asset, BTC_ASSET } from "@/types/common";
 import type { Rune } from "@/types/satsTerminal.ts";
 import { InputArea } from "./InputArea";
@@ -256,11 +257,11 @@ export function SwapTab({
 
         // Force search for the rune if it changes
         // Normalize names by removing spacers for comparison
-        const normalizedPreSelected = preSelectedRune.replace(/•/g, "");
+        const normalizedPreSelected = normalizeRuneName(preSelectedRune);
 
         // Try to find in available runes first
         const rune = availableRunes.find(
-          (r) => r.name.replace(/•/g, "") === normalizedPreSelected,
+          (r) => normalizeRuneName(r.name) === normalizedPreSelected,
         );
 
         if (rune) {
@@ -288,7 +289,7 @@ export function SwapTab({
             if (searchResults && searchResults.length > 0) {
               // Find closest match
               const matchingRune = searchResults.find(
-                (r) => r.name.replace(/•/g, "") === normalizedPreSelected,
+                (r) => normalizeRuneName(r.name) === normalizedPreSelected,
               );
 
               // If found a match or just take the first result if no exact match
@@ -388,8 +389,8 @@ export function SwapTab({
           .filter(
             (rune) =>
               rune.id !== liquidiumToken.id &&
-              rune.name.replace(/•/g, "") !==
-                liquidiumToken.name.replace(/•/g, ""),
+              normalizeRuneName(rune.name) !==
+                normalizeRuneName(liquidiumToken.name),
           );
 
         // Prepend the hardcoded token ONLY if no pre-selected rune
@@ -447,8 +448,8 @@ export function SwapTab({
             .filter(
               (rune) =>
                 rune.id !== liquidiumToken.id &&
-                rune.name.replace(/•/g, "") !==
-                  liquidiumToken.name.replace(/•/g, ""),
+                normalizeRuneName(rune.name) !==
+                  normalizeRuneName(liquidiumToken.name),
             );
 
           mappedRunes = [liquidiumToken, ...fetchedRunes];
@@ -520,7 +521,10 @@ export function SwapTab({
     isLoading: isSwapRuneInfoLoading,
     error: swapRuneInfoError,
   } = useQuery<RuneData | null, Error>({
-    queryKey: ["runeInfoApi", assetIn?.name?.replace(/•/g, "")],
+    queryKey: [
+      "runeInfoApi",
+      assetIn?.name ? normalizeRuneName(assetIn.name) : undefined,
+    ],
     queryFn: () =>
       assetIn && !assetIn.isBTC && assetIn.name
         ? fetchRuneInfoFromApi(assetIn.name)
@@ -1230,7 +1234,7 @@ export function SwapTab({
   ): string | null => {
     if (!runeName || !runeBalances) return null;
     // Ordiscan returns names without spacers, so compare without them
-    const formattedRuneName = runeName.replace(/•/g, "");
+    const formattedRuneName = normalizeRuneName(runeName);
     const found = runeBalances?.find((rb) => rb.name === formattedRuneName);
     return found ? found.balance : "0"; // Return '0' if not found, assuming 0 balance
   };

--- a/src/context/BackgroundContext.tsx
+++ b/src/context/BackgroundContext.tsx
@@ -2,6 +2,8 @@
 
 import React, { createContext, useContext, useState, useEffect } from "react";
 
+const STORAGE_KEY = "runesswap-background";
+
 interface BackgroundContextType {
   backgroundImage: string | null;
   setBackgroundImage: (image: string | null) => void;
@@ -20,7 +22,7 @@ export function BackgroundProvider({
   // Load background from localStorage on mount and save when it changes
   useEffect(() => {
     try {
-      const savedBackground = localStorage.getItem("runesswap-background");
+      const savedBackground = localStorage.getItem(STORAGE_KEY);
       if (savedBackground) setBackgroundImage(savedBackground);
     } catch {
       // Ignore errors (e.g., localStorage not available)
@@ -30,9 +32,9 @@ export function BackgroundProvider({
   useEffect(() => {
     try {
       if (backgroundImage) {
-        localStorage.setItem("runesswap-background", backgroundImage);
+        localStorage.setItem(STORAGE_KEY, backgroundImage);
       } else {
-        localStorage.removeItem("runesswap-background");
+        localStorage.removeItem(STORAGE_KEY);
       }
     } catch {
       // Ignore errors

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -13,6 +13,7 @@ import {
 import { type RuneData } from "./runesData";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { LiquidiumLoanOffer } from "@/types/liquidium"; // Import Liquidium types if needed elsewhere
+import { normalizeRuneName } from "@/utils/runeUtils";
 
 // API Query Keys for React Query caching
 export const QUERY_KEYS = {
@@ -26,7 +27,9 @@ export const QUERY_KEYS = {
   RUNE_ACTIVITY: "runeActivity",
   PORTFOLIO_DATA: "portfolioData",
   LIQUIDIUM_PORTFOLIO: "liquidiumPortfolio",
-};
+} as const;
+
+export type QueryKey = (typeof QUERY_KEYS)[keyof typeof QUERY_KEYS];
 
 // Standard API response handler
 const handleApiResponse = <T>(data: unknown, expectedArrayType = false): T => {
@@ -229,7 +232,7 @@ export const fetchRuneBalancesFromApi = async (
 export const fetchRuneInfoFromApi = async (
   name: string,
 ): Promise<RuneData | null> => {
-  const normalizedName = name.replace(/•/g, "");
+  const normalizedName = normalizeRuneName(name);
   const response = await fetch(
     `/api/ordiscan/rune-info?name=${encodeURIComponent(normalizedName)}`,
   );
@@ -257,7 +260,7 @@ export const fetchRuneInfoFromApi = async (
 export const updateRuneDataViaApi = async (
   name: string,
 ): Promise<RuneData | null> => {
-  const normalizedName = name.replace(/•/g, "");
+  const normalizedName = normalizeRuneName(name);
   const response = await fetch("/api/ordiscan/rune-update", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -287,7 +290,7 @@ export const updateRuneDataViaApi = async (
 export const fetchRuneMarketFromApi = async (
   name: string,
 ): Promise<OrdiscanRuneMarketInfo | null> => {
-  const normalizedName = name.replace(/•/g, "");
+  const normalizedName = normalizeRuneName(name);
   const response = await fetch(
     `/api/ordiscan/rune-market?name=${encodeURIComponent(normalizedName)}`,
   );

--- a/src/lib/runeMarketData.ts
+++ b/src/lib/runeMarketData.ts
@@ -1,5 +1,6 @@
 import { supabase } from "./supabase";
 import { getOrdiscanClient } from "./serverUtils";
+import { normalizeRuneName } from "@/utils/runeUtils";
 
 export interface RuneMarketData {
   price_in_sats: number;
@@ -12,7 +13,7 @@ export async function getRuneMarketData(
   runeName: string,
 ): Promise<RuneMarketData | null> {
   try {
-    const normalizedName = runeName.replace(/•/g, "");
+    const normalizedName = normalizeRuneName(runeName);
 
     // First, try to get from Supabase
     const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);

--- a/src/utils/runeUtils.ts
+++ b/src/utils/runeUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Utility functions for working with Rune names and identifiers.
+ */
+
+/**
+ * Normalize a rune name by removing common separator characters like
+ * bullet ("•") or dots. This helps ensure consistent lookups when
+ * interacting with APIs.
+ */
+export function normalizeRuneName(name: string): string {
+  return name.replace(/[•.]/g, "");
+}


### PR DESCRIPTION
## Summary
- centralize rune name normalization in `runeUtils`
- use new helper in API routes and components
- keep background image key in a constant
- type query keys in `apiClient`
- configure Jest alias mapping

## Testing
- `pnpm test`
- `pnpm lint`
