### PR TITLE
Clean codebase by removing unused comments

### DIFF
--- a/src/app/api/ordiscan/rune-info-by-id/route.ts
+++ b/src/app/api/ordiscan/rune-info-by-id/route.ts
@@ -94,8 +94,7 @@ export async function GET(request: NextRequest) {
           return NextResponse.json(runeData);
         }
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       // Error handled by returning not found
     }
 
@@ -104,8 +103,7 @@ export async function GET(request: NextRequest) {
       { error: "Rune not found with the given prefix" },
       { status: 404 },
     );
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return NextResponse.json(
       { error: "Internal server error" },
       { status: 500 },

--- a/src/app/api/sats-terminal/psbt/confirm/route.ts
+++ b/src/app/api/sats-terminal/psbt/confirm/route.ts
@@ -14,7 +14,6 @@ type ConfirmParams = z.infer<typeof confirmPsbtParamsSchema>;
 const confirmPsbtParamsSchema = z
   .object({
     orders: z.array(runeOrderSchema),
-    // TODO: Use a Bitcoin address validation library for full validation (e.g., bitcoinjs-lib)
     address: z
       .string()
       .regex(

--- a/src/components/FormattedRuneAmount.tsx
+++ b/src/components/FormattedRuneAmount.tsx
@@ -64,8 +64,7 @@ export function FormattedRuneAmount({
       // Format even if 0 decimals for consistency (e.g., add commas)
       const amountNum = BigInt(rawAmount); // Use BigInt for potentially large raw amounts
       return <span>{amountNum.toLocaleString()}</span>;
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       return <span>{rawAmount} (Invalid Raw)</span>; // Fallback for invalid rawAmount
     }
   }
@@ -92,8 +91,7 @@ export function FormattedRuneAmount({
         })}
       </span>
     );
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return <span>{rawAmount} (Formatting Error)</span>; // Fallback
   }
 }

--- a/src/components/SwapTab.tsx
+++ b/src/components/SwapTab.tsx
@@ -328,8 +328,7 @@ export function SwapTab({
               // Clear search field
               setSearchQuery("");
             }
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          } catch (error) {
+          } catch {
             // Error handled in finally block
           } finally {
             setIsSearching(false);
@@ -979,8 +978,7 @@ export function SwapTab({
       } else {
         setOutputUsdValue(null);
       }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (error) {
+    } catch {
       setInputUsdValue(null);
       setOutputUsdValue(null);
     }
@@ -1267,8 +1265,7 @@ export function SwapTab({
 
         decimals = swapRuneInfo?.decimals ?? 0;
         availableBalance = balanceNum / 10 ** decimals;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
+      } catch {
         return;
       }
     }

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -11,8 +11,6 @@ import {
   type ConfirmPSBTParams,
 } from "satsterminal-sdk";
 import { type RuneData } from "./runesData";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import type { LiquidiumLoanOffer } from "@/types/liquidium"; // Import Liquidium types if needed elsewhere
 import { normalizeRuneName } from "@/utils/runeUtils";
 
 // API Query Keys for React Query caching

--- a/src/lib/popularRunesCache.ts
+++ b/src/lib/popularRunesCache.ts
@@ -43,8 +43,7 @@ export async function getCachedPopularRunesWithExpiry(): Promise<{
       cachedData: data.runes_data as Record<string, unknown>[],
       isExpired,
     };
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return { cachedData: null, isExpired: true };
   }
 }
@@ -65,8 +64,7 @@ export async function getCachedPopularRunes(): Promise<
     }
 
     return null;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -87,8 +85,7 @@ export async function cachePopularRunes(
     ]);
 
     // Errors in caching are non-critical
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // Errors in caching are non-critical
   }
 }

--- a/src/lib/runesData.ts
+++ b/src/lib/runesData.ts
@@ -58,9 +58,7 @@ export async function getRuneData(runeName: string): Promise<RuneData | null> {
     // even if caching to DB fails
 
     return runeData as RuneData;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return null;
   }
 }
-

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -25,8 +25,7 @@ export function formatNumberString(
     const withCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
     const result = decPart ? `${withCommas}.${decPart}` : withCommas;
     return isNegative ? `-${result}` : result;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     return defaultDisplay;
   }
 }

--- a/src/utils/transactionHelpers.ts
+++ b/src/utils/transactionHelpers.ts
@@ -154,8 +154,7 @@ export function interpretRuneTransaction(
         runeAmountRaw = "N/A"; // Amount for external transfers is ambiguous
       }
     }
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (error) {
+  } catch {
     // Default values will be returned
   }
 


### PR DESCRIPTION
## Summary
- remove unused Liquidium type import
- clean up catch blocks and remove eslint directives
- trim leftover TODO
- tidy formatting utilities

## Testing
- `pnpm lint`
- `pnpm build` *(fails: Missing env.NEXT_PUBLIC_SUPABASE_URL)*