### PR TITLE
Fix Sats Terminal swap flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@
 # IMPORTANT: Do not commit this file to Git!
 
 SATS_TERMINAL_API_KEY=
+TBA_API_URL=
 ORDISCAN_API_KEY=
 RUNES_FLOOR_API_KEY=
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ NEXT_PUBLIC_SUPABASE_URL=<your-supabase-url>
 NEXT_PUBLIC_SUPABASE_ANON_KEY=<your-supabase-anon-key>
 ORDISCAN_API_KEY=<your-ordiscan-api-key>
 SATS_TERMINAL_API_KEY=<your-satsterminal-api-key>
+TBA_API_URL=<your-satsterminal-api-url>
 ```
 
 ### Installation & Development

--- a/src/lib/serverUtils.ts
+++ b/src/lib/serverUtils.ts
@@ -35,6 +35,7 @@ export function getOrdiscanClient(): Ordiscan {
  */
 export function getSatsTerminalClient(): SatsTerminal {
   const apiKey = process.env.SATS_TERMINAL_API_KEY;
+  const baseUrl = process.env.TBA_API_URL;
 
   if (!apiKey) {
     console.error(
@@ -44,7 +45,7 @@ export function getSatsTerminalClient(): SatsTerminal {
   }
 
   // Note: The SatsTerminal constructor expects an options object.
-  return new SatsTerminal({ apiKey });
+  return new SatsTerminal(baseUrl ? { apiKey, baseUrl } : { apiKey });
 }
 
 /**


### PR DESCRIPTION
## Summary
- handle cancelation by resetting swap state
- mark expired quotes when wallet cancels signing
- track quote timestamps to prevent using stale quotes
- support new SatsTerminal base URL and `newFetchQuote`
- document `TBA_API_URL`

## Testing
- `pnpm lint`
- `pnpm test`
