### PR TITLE
Add build step to husky pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,3 +6,6 @@ npx lint-staged
 
 # Run tests
 pnpm test
+
+# Run production build
+pnpm build

--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ RunesSwap.app charges no additional fees beyond SatsTerminal network fees and st
 
 ## Contributing
 
-Contributions are welcome via pull requests. Please ensure:
+Contributions are welcome via pull requests. The pre-commit hook automatically
+runs linting, tests and a production build. Please ensure:
 - Code builds successfully (`pnpm build`).
 - Linting & formatting pass (`pnpm lint`).
 - New features include tests and documentation updates.


### PR DESCRIPTION
## Summary
- ensure the husky pre-commit hook also runs the production build
- document pre-commit behaviour in the contributing section of the README

## Testing
- `pnpm lint` *(fails: formattingError is defined but never used)*
- `pnpm test`
- `pnpm build` *(fails to compile)*