### PR TITLE
Improve Supabase proxy error

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -12,8 +12,12 @@ if (!supabaseUrl || !supabaseAnonKey) {
   supabase = new Proxy(
     {},
     {
-      get() {
-        throw new Error("Supabase client is not configured");
+      get(target, prop) {
+        throw new Error(
+          `Supabase client is not configured. Attempted to access property: ${String(
+            prop,
+          )}`,
+        );
       },
     },
   ) as SupabaseClient;


### PR DESCRIPTION
## Summary
- enhance `supabase` fallback proxy to expose `target` and `prop` parameters
- include accessed property name in thrown error message

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`