### PR TITLE
Fix swap direction check

### DIFF
--- a/src/components/SwapTab.tsx
+++ b/src/components/SwapTab.tsx
@@ -644,8 +644,11 @@ export function SwapTab({
 
   // --- Swap Direction Logic ---
   const handleSwapDirection = () => {
+    if (!assetOut) {
+      return;
+    }
     const tempAsset = assetIn;
-    setAssetIn(assetOut ?? BTC_ASSET);
+    setAssetIn(assetOut);
     setAssetOut(tempAsset);
 
     const tempAmount = inputAmount;


### PR DESCRIPTION
## Summary
- ensure handleSwapDirection exits early when no output asset is selected

## Testing
- `pnpm lint`
- `pnpm test`
