### PR TITLE
Refactor portfolio tab with new hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,4 +108,5 @@ When implementing complex features, prefer splitting large components into small
 Stateful logic can be moved to custom hooks under `src/hooks`, while reusable UI pieces 
 should live in their own components inside `src/components`. Existing examples include
 `AssetSelector` and `AmountHelpers` extracted from `InputArea`, and the `usePriceHistory`
-hook powering `PriceChart`.
+hook powering `PriceChart`. Additional hooks such as `usePortfolioData`,
+`useLiquidiumAuth`, and `useRepayModal` keep the Portfolio tab logic modular.

--- a/src/components/PortfolioTab.tsx
+++ b/src/components/PortfolioTab.tsx
@@ -1,35 +1,41 @@
-import { useQuery } from "@tanstack/react-query";
-import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSharedLaserEyes } from "@/context/LaserEyesContext";
-import { fetchPortfolioDataFromApi, QUERY_KEYS } from "@/lib/apiClient";
-import { LiquidiumLoanOffer } from "@/types/liquidium";
 import styles from "./PortfolioTab.module.css";
 import RunesPortfolioTable from "./RunesPortfolioTable";
 import LiquidiumLoansSection from "./LiquidiumLoansSection";
 import RepayModal from "./RepayModal";
-import { useLiquidiumPortfolio } from "@/hooks/useLiquidiumPortfolio";
-
-type SortField = "name" | "balance" | "value";
-type SortDirection = "asc" | "desc";
+import usePortfolioData from "@/hooks/usePortfolioData";
+import useLiquidiumAuth from "@/hooks/useLiquidiumAuth";
+import { useRepayModal } from "@/hooks/useRepayModal";
 
 export default function PortfolioTab() {
   const router = useRouter();
   const { address, paymentAddress, signMessage, signPsbt } =
     useSharedLaserEyes();
-  const [sortField, setSortField] = useState<SortField>("value");
-  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
-  const [progress, setProgress] = useState(0); // 0 to 1
-  const [stepText, setStepText] = useState("");
-  const [liquidiumAuthenticated, setLiquidiumAuthenticated] = useState(false);
-  const [isAuthenticating, setIsAuthenticating] = useState(false);
-  const [isCheckingAuth, setIsCheckingAuth] = useState(false);
-  const [authError, setAuthError] = useState<string | null>(null);
-  const [liquidiumLoans, setLiquidiumLoans] = useState<LiquidiumLoanOffer[]>(
-    [],
-  );
-  const [isLoadingLiquidium, setIsLoadingLiquidium] = useState(false);
-  const [liquidiumError, setLiquidiumError] = useState<string | null>(null);
+
+  const {
+    sortedBalances,
+    totalBtcValue,
+    totalUsdValue,
+    sortField,
+    sortDirection,
+    handleSort,
+    progress,
+    stepText,
+    isLoading,
+    error,
+  } = usePortfolioData(address);
+
+  const {
+    liquidiumAuthenticated,
+    isAuthenticating,
+    isCheckingAuth,
+    authError,
+    liquidiumLoans,
+    isLoadingLiquidium,
+    liquidiumError,
+    handleLiquidiumAuth,
+  } = useLiquidiumAuth({ address, paymentAddress, signMessage });
 
   const {
     isRepayingLoanId,
@@ -37,211 +43,18 @@ export default function PortfolioTab() {
     handleRepay,
     handleRepayModalClose,
     handleRepayModalConfirm,
-  } = useLiquidiumPortfolio({ address, signPsbt });
-
-  // Use the new batch API endpoint for runes portfolio
-  const {
-    data: portfolioData,
-    isLoading,
-    error,
-  } = useQuery({
-    queryKey: [QUERY_KEYS.PORTFOLIO_DATA, address],
-    queryFn: () => fetchPortfolioDataFromApi(address || ""),
-    enabled: !!address,
-    staleTime: 30000, // Cache for 30 seconds
-  });
-
-  const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
-    } else {
-      setSortField(field);
-      setSortDirection("desc");
-    }
-  };
+  } = useRepayModal({ address, signPsbt });
 
   const handleSwap = (runeName: string) => {
-    // Update URL without page refresh
     router.push(`/?tab=swap&rune=${encodeURIComponent(runeName)}`, {
       scroll: false,
     });
-    // Emit custom event to notify parent components
     window.dispatchEvent(
       new CustomEvent("tabChange", { detail: { tab: "swap", rune: runeName } }),
     );
   };
 
-  // Simulate progress bar during loading
-  useEffect(() => {
-    if (!isLoading) return;
-    let isMounted = true;
-    let step = 0;
-    const totalSteps = 4; // 1: balances, 2: rune info, 3: market data, 4: finalizing
-    const stepLabels = [
-      "Fetching balances...",
-      "Fetching rune info...",
-      "Fetching market data...",
-      "Finalizing...",
-    ];
-    setProgress(0);
-    setStepText(stepLabels[0]);
-    function nextStep() {
-      if (!isMounted) return;
-      step++;
-      if (step < totalSteps) {
-        setProgress(step / totalSteps);
-        setStepText(stepLabels[step]);
-        setTimeout(nextStep, 400 + Math.random() * 400); // Simulate 400-800ms per step
-      } else {
-        setProgress(1);
-        setStepText("Finalizing...");
-      }
-    }
-    setTimeout(nextStep, 400 + Math.random() * 400);
-    return () => {
-      isMounted = false;
-    };
-  }, [isLoading]);
-
-  // Liquidium connect/auth handler
-  const handleLiquidiumAuth = async () => {
-    setIsAuthenticating(true);
-    setAuthError(null);
-    try {
-      if (!address || !paymentAddress) {
-        setAuthError("Wallet connection required for authentication");
-
-        setIsAuthenticating(false);
-        return;
-      }
-      if (!signMessage) {
-        setAuthError("Your wallet does not support message signing");
-
-        setIsAuthenticating(false);
-        return;
-      }
-      // Step 1: Get challenge from backend
-
-      const challengeRes = await fetch(
-        `/api/liquidium/challenge?ordinalsAddress=${encodeURIComponent(address)}&paymentAddress=${encodeURIComponent(paymentAddress)}`,
-      );
-      const challengeData = await challengeRes.json();
-      if (!challengeRes.ok) {
-        setAuthError(challengeData?.error || "Failed to get challenge");
-
-        setIsAuthenticating(false);
-        return;
-      }
-      const { ordinals, payment } = challengeData.data;
-      // Step 2: Sign messages
-
-      const ordinalsSignature = await signMessage(ordinals.message, address);
-      let paymentSignature: string | undefined;
-      if (payment) {
-        paymentSignature = await signMessage(payment.message, paymentAddress);
-      }
-      // Step 3: Submit signatures to backend
-
-      const authRes = await fetch("/api/liquidium/auth", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          ordinalsAddress: address,
-          paymentAddress,
-          ordinalsSignature,
-          paymentSignature,
-          ordinalsNonce: ordinals.nonce,
-          paymentNonce: payment?.nonce,
-        }),
-      });
-      const authData = await authRes.json();
-      if (!authRes.ok) {
-        setAuthError(authData?.error || "Authentication failed");
-
-        setIsAuthenticating(false);
-        return;
-      }
-      setLiquidiumAuthenticated(true);
-
-      // Fetch loans after auth
-      fetchLiquidiumLoans();
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        setAuthError(err.message || "Unknown error");
-      } else {
-        setAuthError("Unknown error");
-      }
-    } finally {
-      setIsAuthenticating(false);
-    }
-  };
-
-  // Fetch Liquidium loans from backend
-  const fetchLiquidiumLoans = async () => {
-    setIsLoadingLiquidium(true);
-    setLiquidiumError(null);
-    try {
-      const res = await fetch(
-        `/api/liquidium/portfolio?address=${encodeURIComponent(address || "")}`,
-      );
-      const data = await res.json();
-      if (!res.ok) {
-        setLiquidiumError(data?.error || "Failed to fetch loans");
-        setLiquidiumLoans([]);
-
-        return;
-      }
-      setLiquidiumLoans(data.data || []);
-    } catch (err: unknown) {
-      if (err instanceof Error) {
-        setLiquidiumError(err.message || "Unknown error");
-        setLiquidiumLoans([]);
-      } else {
-        setLiquidiumError("Unknown error");
-        setLiquidiumLoans([]);
-      }
-    } finally {
-      setIsLoadingLiquidium(false);
-    }
-  };
-
-  // On mount or when address changes, check if already authenticated
-  useEffect(() => {
-    if (!address) return;
-    const checkAuth = async () => {
-      setIsCheckingAuth(true);
-      try {
-        const res = await fetch(
-          `/api/liquidium/portfolio?address=${encodeURIComponent(address)}`,
-        );
-        if (res.status === 200) {
-          setLiquidiumAuthenticated(true);
-          const data = await res.json();
-          setLiquidiumLoans(data.data || []);
-        } else if (res.status === 401) {
-          setLiquidiumAuthenticated(false);
-          setLiquidiumLoans([]);
-        } else {
-          setLiquidiumAuthenticated(false);
-          setLiquidiumLoans([]);
-        }
-      } catch {
-        setLiquidiumAuthenticated(false);
-        setLiquidiumLoans([]);
-      } finally {
-        setIsCheckingAuth(false);
-      }
-    };
-    checkAuth();
-  }, [address]);
-
-  // Minimal repay handler
-
-  // Log repayModal state when opening modal
-  useEffect(() => {
-    if (repayModal.open) {
-    }
-  }, [repayModal, repayModal.open]);
+  const formatSatsToBtc = (sats: number): string => (sats / 1e8).toFixed(8);
 
   if (!address) {
     return (
@@ -275,7 +88,7 @@ export default function PortfolioTab() {
     );
   }
 
-  if (!portfolioData?.balances?.length) {
+  if (!sortedBalances.length) {
     return (
       <div className={styles.container}>
         <div>No runes found in your wallet</div>
@@ -283,64 +96,8 @@ export default function PortfolioTab() {
     );
   }
 
-  // Calculate values and sort the balances
-  const sortedBalances = [...portfolioData.balances]
-    .map((rune) => {
-      const marketInfo = portfolioData.marketData?.[rune.name];
-      const runeInfo = portfolioData.runeInfos?.[rune.name];
-      const decimals = runeInfo?.decimals || 0;
-      const actualBalance = Number(rune.balance) / Math.pow(10, decimals);
-      const btcValue = marketInfo?.price_in_sats
-        ? (actualBalance * marketInfo.price_in_sats) / 1e8
-        : 0;
-      const usdValue = marketInfo?.price_in_usd
-        ? actualBalance * marketInfo.price_in_usd
-        : 0;
-      const imageURI = `https://icon.unisat.io/icon/runes/${encodeURIComponent(rune.name)}`;
-
-      return {
-        ...rune,
-        actualBalance,
-        btcValue,
-        usdValue,
-        imageURI,
-        formattedName: runeInfo?.formatted_name || rune.name,
-      };
-    })
-    .sort((a, b) => {
-      let comparison = 0;
-      switch (sortField) {
-        case "name":
-          comparison = a.name.localeCompare(b.name);
-          break;
-        case "balance":
-          comparison = a.actualBalance - b.actualBalance;
-          break;
-        case "value":
-          comparison = a.usdValue - b.usdValue;
-          break;
-      }
-      return sortDirection === "asc" ? comparison : -comparison;
-    });
-
-  // Calculate totals
-  const totalBtcValue = sortedBalances.reduce(
-    (sum, rune) => sum + rune.btcValue,
-    0,
-  );
-  const totalUsdValue = sortedBalances.reduce(
-    (sum, rune) => sum + rune.usdValue,
-    0,
-  );
-
-  // Helper function to format loan status
-
-  // Helper function to format sats to BTC
-  const formatSatsToBtc = (sats: number): string => (sats / 1e8).toFixed(8);
-
   return (
     <div className={styles.container}>
-      {/* Runes Portfolio Section */}
       <RunesPortfolioTable
         balances={sortedBalances}
         totalBtcValue={totalBtcValue}
@@ -351,7 +108,6 @@ export default function PortfolioTab() {
         onSwap={handleSwap}
       />
 
-      {/* Liquidium Loans Section */}
       <div className={styles.sectionDivider}>
         <div className={styles.dividerLine + " " + styles.top}></div>
         <div className={styles.dividerLine + " " + styles.bottom}></div>

--- a/src/hooks/useLiquidiumAuth.ts
+++ b/src/hooks/useLiquidiumAuth.ts
@@ -1,0 +1,149 @@
+import { useState, useEffect } from "react";
+import { LiquidiumLoanOffer } from "@/types/liquidium";
+
+interface UseLiquidiumAuthArgs {
+  address: string | null;
+  paymentAddress: string | null;
+  signMessage?: (message: string, address: string) => Promise<string>;
+}
+
+export function useLiquidiumAuth({
+  address,
+  paymentAddress,
+  signMessage,
+}: UseLiquidiumAuthArgs) {
+  const [liquidiumAuthenticated, setLiquidiumAuthenticated] = useState(false);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [isCheckingAuth, setIsCheckingAuth] = useState(false);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const [liquidiumLoans, setLiquidiumLoans] = useState<LiquidiumLoanOffer[]>(
+    [],
+  );
+  const [isLoadingLiquidium, setIsLoadingLiquidium] = useState(false);
+  const [liquidiumError, setLiquidiumError] = useState<string | null>(null);
+
+  const fetchLiquidiumLoans = async () => {
+    setIsLoadingLiquidium(true);
+    setLiquidiumError(null);
+    try {
+      const res = await fetch(
+        `/api/liquidium/portfolio?address=${encodeURIComponent(address || "")}`,
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        setLiquidiumError(data?.error || "Failed to fetch loans");
+        setLiquidiumLoans([]);
+        return;
+      }
+      setLiquidiumLoans(data.data || []);
+    } catch (err: unknown) {
+      setLiquidiumError(err instanceof Error ? err.message : "Unknown error");
+      setLiquidiumLoans([]);
+    } finally {
+      setIsLoadingLiquidium(false);
+    }
+  };
+
+  const handleLiquidiumAuth = async () => {
+    setIsAuthenticating(true);
+    setAuthError(null);
+    try {
+      if (!address || !paymentAddress) {
+        setAuthError("Wallet connection required for authentication");
+        setIsAuthenticating(false);
+        return;
+      }
+      if (!signMessage) {
+        setAuthError("Your wallet does not support message signing");
+        setIsAuthenticating(false);
+        return;
+      }
+
+      const challengeRes = await fetch(
+        `/api/liquidium/challenge?ordinalsAddress=${encodeURIComponent(
+          address,
+        )}&paymentAddress=${encodeURIComponent(paymentAddress)}`,
+      );
+      const challengeData = await challengeRes.json();
+      if (!challengeRes.ok) {
+        setAuthError(challengeData?.error || "Failed to get challenge");
+        setIsAuthenticating(false);
+        return;
+      }
+      const { ordinals, payment } = challengeData.data;
+      const ordinalsSignature = await signMessage(ordinals.message, address);
+      let paymentSignature: string | undefined;
+      if (payment) {
+        paymentSignature = await signMessage(payment.message, paymentAddress);
+      }
+      const authRes = await fetch("/api/liquidium/auth", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ordinalsAddress: address,
+          paymentAddress,
+          ordinalsSignature,
+          paymentSignature,
+          ordinalsNonce: ordinals.nonce,
+          paymentNonce: payment?.nonce,
+        }),
+      });
+      const authData = await authRes.json();
+      if (!authRes.ok) {
+        setAuthError(authData?.error || "Authentication failed");
+        setIsAuthenticating(false);
+        return;
+      }
+      setLiquidiumAuthenticated(true);
+      fetchLiquidiumLoans();
+    } catch (err: unknown) {
+      setAuthError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setIsAuthenticating(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!address) return;
+    const checkAuth = async () => {
+      setIsCheckingAuth(true);
+      try {
+        const res = await fetch(
+          `/api/liquidium/portfolio?address=${encodeURIComponent(address)}`,
+        );
+        if (res.status === 200) {
+          setLiquidiumAuthenticated(true);
+          const data = await res.json();
+          setLiquidiumLoans(data.data || []);
+        } else if (res.status === 401) {
+          setLiquidiumAuthenticated(false);
+          setLiquidiumLoans([]);
+        } else {
+          setLiquidiumAuthenticated(false);
+          setLiquidiumLoans([]);
+        }
+      } catch {
+        setLiquidiumAuthenticated(false);
+        setLiquidiumLoans([]);
+      } finally {
+        setIsCheckingAuth(false);
+      }
+    };
+    checkAuth();
+  }, [address]);
+
+  return {
+    liquidiumAuthenticated,
+    isAuthenticating,
+    isCheckingAuth,
+    authError,
+    liquidiumLoans,
+    isLoadingLiquidium,
+    liquidiumError,
+    handleLiquidiumAuth,
+    fetchLiquidiumLoans,
+  };
+}
+
+export default useLiquidiumAuth;

--- a/src/hooks/usePortfolioData.ts
+++ b/src/hooks/usePortfolioData.ts
@@ -1,0 +1,143 @@
+import { useState, useEffect, useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPortfolioDataFromApi, QUERY_KEYS } from "@/lib/apiClient";
+
+export type SortField = "name" | "balance" | "value";
+export type SortDirection = "asc" | "desc";
+
+export interface RuneBalanceItem {
+  name: string;
+  formattedName: string;
+  balance: string;
+  imageURI?: string;
+  usdValue: number;
+  actualBalance: number;
+  btcValue: number;
+}
+
+export function usePortfolioData(address: string | null) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: [QUERY_KEYS.PORTFOLIO_DATA, address],
+    queryFn: () => fetchPortfolioDataFromApi(address || ""),
+    enabled: !!address,
+    staleTime: 30000,
+  });
+
+  const [progress, setProgress] = useState(0);
+  const [stepText, setStepText] = useState("");
+
+  useEffect(() => {
+    if (!isLoading) return;
+    let isMounted = true;
+    let step = 0;
+    const totalSteps = 4;
+    const stepLabels = [
+      "Fetching balances...",
+      "Fetching rune info...",
+      "Fetching market data...",
+      "Finalizing...",
+    ];
+    setProgress(0);
+    setStepText(stepLabels[0]);
+    function nextStep() {
+      if (!isMounted) return;
+      step++;
+      if (step < totalSteps) {
+        setProgress(step / totalSteps);
+        setStepText(stepLabels[step]);
+        setTimeout(nextStep, 400 + Math.random() * 400);
+      } else {
+        setProgress(1);
+        setStepText("Finalizing...");
+      }
+    }
+    const t = setTimeout(nextStep, 400 + Math.random() * 400);
+    return () => {
+      isMounted = false;
+      clearTimeout(t);
+    };
+  }, [isLoading]);
+
+  const [sortField, setSortField] = useState<SortField>("value");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
+    } else {
+      setSortField(field);
+      setSortDirection("desc");
+    }
+  };
+
+  const sortedBalances = useMemo<RuneBalanceItem[]>(() => {
+    if (!data?.balances) return [] as RuneBalanceItem[];
+    const balances = data.balances.map((rune) => {
+      const marketInfo = data.marketData?.[rune.name];
+      const runeInfo = data.runeInfos?.[rune.name];
+      const decimals = runeInfo?.decimals || 0;
+      const actualBalance = Number(rune.balance) / Math.pow(10, decimals);
+      const btcValue = marketInfo?.price_in_sats
+        ? (actualBalance * marketInfo.price_in_sats) / 1e8
+        : 0;
+      const usdValue = marketInfo?.price_in_usd
+        ? actualBalance * marketInfo.price_in_usd
+        : 0;
+      const imageURI = `https://icon.unisat.io/icon/runes/${encodeURIComponent(
+        rune.name,
+      )}`;
+
+      return {
+        ...rune,
+        actualBalance,
+        btcValue,
+        usdValue,
+        imageURI,
+        formattedName: runeInfo?.formatted_name || rune.name,
+      };
+    });
+
+    balances.sort((a, b) => {
+      let comparison = 0;
+      switch (sortField) {
+        case "name":
+          comparison = a.name.localeCompare(b.name);
+          break;
+        case "balance":
+          comparison = a.actualBalance - b.actualBalance;
+          break;
+        case "value":
+          comparison = a.usdValue - b.usdValue;
+          break;
+      }
+      return sortDirection === "asc" ? comparison : -comparison;
+    });
+
+    return balances;
+  }, [data, sortField, sortDirection]);
+
+  const totalBtcValue = useMemo(
+    () => sortedBalances.reduce((sum, rune) => sum + rune.btcValue, 0),
+    [sortedBalances],
+  );
+  const totalUsdValue = useMemo(
+    () => sortedBalances.reduce((sum, rune) => sum + rune.usdValue, 0),
+    [sortedBalances],
+  );
+
+  return {
+    data,
+    isLoading,
+    error,
+    progress,
+    stepText,
+    sortedBalances,
+    totalBtcValue,
+    totalUsdValue,
+    sortField,
+    sortDirection,
+    handleSort,
+  };
+}
+
+export default usePortfolioData;

--- a/src/hooks/useRepayModal.ts
+++ b/src/hooks/useRepayModal.ts
@@ -6,7 +6,7 @@ import {
 } from "@/lib/apiClient";
 import { LiquidiumLoanOffer } from "@/types/liquidium";
 
-interface UseLiquidiumPortfolioArgs {
+interface UseRepayModalArgs {
   address: string | null;
   signPsbt?: (
     tx: string,
@@ -17,10 +17,7 @@ interface UseLiquidiumPortfolioArgs {
   >;
 }
 
-export function useLiquidiumPortfolio({
-  address,
-  signPsbt,
-}: UseLiquidiumPortfolioArgs) {
+export function useRepayModal({ address, signPsbt }: UseRepayModalArgs) {
   const [isRepayingLoanId, setIsRepayingLoanId] = useState<string | null>(null);
   const [repayModal, setRepayModal] = useState<{
     open: boolean;


### PR DESCRIPTION
## Summary
- add `usePortfolioData` hook for fetching & sorting balances
- add `useLiquidiumAuth` hook for Liquidium auth and loans
- rename `useLiquidiumPortfolio` to `useRepayModal`
- clean up `PortfolioTab` to consume hooks
- document hooks in `AGENTS.md`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
