### PR TITLE
Refactor asset selector to use custom hook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,3 +109,4 @@ Stateful logic can be moved to custom hooks under `src/hooks`, while reusable UI
 should live in their own components inside `src/components`. Existing examples include
 `AssetSelector` and `AmountHelpers` extracted from `InputArea`, and the `usePriceHistory`
 hook powering `PriceChart`.
+\nThe AssetSelector logic has been split further: search state now lives in the `useAssetSearch` hook and the dropdown UI resides in `AssetSelectorDropdown`. `AssetSelector` composes these pieces.

--- a/src/components/AssetSelector.tsx
+++ b/src/components/AssetSelector.tsx
@@ -1,11 +1,7 @@
-import React, { useState, Fragment } from "react";
-import Image from "next/image";
-import { Listbox, Transition } from "@headlessui/react";
-import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/24/solid";
-import styles from "./InputArea.module.css";
-import { Asset, BTC_ASSET } from "@/types/common";
-import { fetchRunesFromApi } from "@/lib/apiClient";
-import type { Rune } from "@/types/satsTerminal";
+import React from "react";
+import { Asset } from "@/types/common";
+import useAssetSearch from "@/hooks/useAssetSearch";
+import AssetSelectorDropdown from "./AssetSelectorDropdown";
 
 interface AssetSelectorProps {
   selectedAsset: Asset | null;
@@ -28,268 +24,32 @@ const AssetSelector: React.FC<AssetSelectorProps> = ({
   assetsError = null,
   isPreselectedAssetLoading = false,
 }) => {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [loadingDots, setLoadingDots] = useState("");
-  const [isSearching, setIsSearching] = useState(false);
-  const [searchResults, setSearchResults] = useState<Asset[]>([]);
-  const [searchError, setSearchError] = useState<string | null>(null);
+  const {
+    searchQuery,
+    handleSearchChange,
+    availableAssets: searchAssets,
+    isLoadingAssets,
+    currentError,
+  } = useAssetSearch();
 
-  React.useEffect(() => {
-    const shouldAnimate =
-      isAssetsLoading || isPreselectedAssetLoading || isSearching;
-
-    if (!shouldAnimate) {
-      setLoadingDots("");
-      return;
-    }
-
-    const interval = setInterval(() => {
-      setLoadingDots((prev) => (prev === "..." ? "" : prev + "."));
-    }, 500);
-
-    return () => clearInterval(interval);
-  }, [isAssetsLoading, isPreselectedAssetLoading, isSearching]);
-
-  const isValidImageSrc = (src?: string | null): src is string => {
-    if (!src || typeof src !== "string") return false;
-    return (
-      src.startsWith("http") || src.startsWith("/") || src.startsWith("data:")
-    );
-  };
-
-  const handleSearchChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const query = e.target.value;
-    setSearchQuery(query);
-
-    if (!query.trim()) {
-      setSearchResults([]);
-      setIsSearching(false);
-      setSearchError(null);
-      return;
-    }
-
-    setIsSearching(true);
-    setSearchError(null);
-
-    try {
-      const results: Rune[] = await fetchRunesFromApi(query);
-      const mappedResults: Asset[] = results.map((rune) => ({
-        id: rune.id,
-        name: rune.name,
-        imageURI: rune.imageURI,
-        isBTC: false,
-      }));
-      setSearchResults(mappedResults);
-    } catch (error: unknown) {
-      setSearchError(
-        error instanceof Error ? error.message : "Failed to search",
-      );
-      setSearchResults([]);
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
-  const displayedAssets = searchQuery.trim() ? searchResults : availableAssets;
-  const isLoadingAssets = searchQuery.trim() ? isSearching : isAssetsLoading;
-  const currentError = searchQuery.trim() ? searchError : assetsError;
+  // Merge assets passed via props with those from the hook when no search query
+  const combinedAssets = searchQuery.trim() ? searchAssets : availableAssets;
+  const loading = searchQuery.trim() ? isLoadingAssets : isAssetsLoading;
+  const error = searchQuery.trim() ? currentError : assetsError;
 
   return (
-    <div className={styles.listboxContainer}>
-      <Listbox
-        value={selectedAsset}
-        onChange={onAssetChange}
-        disabled={disabled || isAssetsLoading || isPreselectedAssetLoading}
-      >
-        <div className={styles.listboxRelative}>
-          <Listbox.Button className={styles.listboxButton}>
-            <span className={styles.listboxButtonText}>
-              {isPreselectedAssetLoading ? (
-                <span className={styles.loadingText}>
-                  Loading Rune{loadingDots}
-                </span>
-              ) : (
-                <>
-                  {isValidImageSrc(selectedAsset?.imageURI) ? (
-                    <Image
-                      src={selectedAsset.imageURI!}
-                      alt={`${selectedAsset.name} logo`}
-                      className={styles.assetButtonImage}
-                      width={24}
-                      height={24}
-                      aria-hidden="true"
-                      onError={(e) => {
-                        const target = e.target as HTMLImageElement;
-                        if (target) target.style.display = "none";
-                      }}
-                    />
-                  ) : null}
-                  {isAssetsLoading
-                    ? `Loading${loadingDots}`
-                    : selectedAsset
-                      ? selectedAsset.name
-                      : "Select Asset"}
-                </>
-              )}
-            </span>
-            <span className={styles.listboxButtonIconContainer}>
-              <ChevronUpDownIcon
-                className={styles.listboxButtonIcon}
-                aria-hidden="true"
-              />
-            </span>
-          </Listbox.Button>
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <Listbox.Options className={styles.listboxOptions}>
-              <div className={styles.searchContainer}>
-                <div className={styles.searchWrapper}>
-                  <Image
-                    src="/icons/magnifying_glass-0.png"
-                    alt="Search"
-                    className={styles.searchIconEmbedded}
-                    width={16}
-                    height={16}
-                  />
-                  <input
-                    type="text"
-                    placeholder="Search runes..."
-                    value={searchQuery}
-                    onChange={handleSearchChange}
-                    className={styles.searchInput}
-                  />
-                </div>
-              </div>
-
-              {isLoadingAssets && (
-                <div className={styles.listboxLoadingOrEmpty}>
-                  Loading Runes{loadingDots}
-                </div>
-              )}
-              {!isLoadingAssets && currentError && (
-                <div
-                  className={`${styles.listboxError} ${styles.messageWithIcon}`}
-                >
-                  <Image
-                    src="/icons/msg_error-0.png"
-                    alt="Error"
-                    className={styles.messageIcon}
-                    width={16}
-                    height={16}
-                  />
-                  <span>{currentError}</span>
-                </div>
-              )}
-              {!isLoadingAssets &&
-                !currentError &&
-                displayedAssets.length === 0 && (
-                  <div className={styles.listboxLoadingOrEmpty}>
-                    {searchQuery
-                      ? "No matching runes found"
-                      : "No runes available"}
-                  </div>
-                )}
-
-              {showBtcInSelector &&
-                (searchQuery.trim() === "" ||
-                  BTC_ASSET.name
-                    .toLowerCase()
-                    .includes(searchQuery.trim().toLowerCase())) && (
-                  <Listbox.Option
-                    key={BTC_ASSET.id}
-                    className={({ active }) =>
-                      `${styles.listboxOption} ${active ? styles.listboxOptionActive : styles.listboxOptionInactive}`
-                    }
-                    value={BTC_ASSET}
-                  >
-                    {({ selected }) => (
-                      <>
-                        <span className={styles.runeOptionContent}>
-                          {isValidImageSrc(BTC_ASSET.imageURI) ? (
-                            <Image
-                              src={BTC_ASSET.imageURI}
-                              alt=""
-                              className={styles.runeImage}
-                              width={24}
-                              height={24}
-                              aria-hidden="true"
-                            />
-                          ) : null}
-                          <span
-                            className={`${styles.listboxOptionText} ${selected ? styles.listboxOptionTextSelected : styles.listboxOptionTextUnselected}`}
-                          >
-                            {BTC_ASSET.name}
-                          </span>
-                        </span>
-                        {selected && (
-                          <span className={styles.listboxOptionCheckContainer}>
-                            <CheckIcon
-                              className={styles.listboxOptionCheckIcon}
-                              aria-hidden="true"
-                            />
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </Listbox.Option>
-                )}
-
-              {displayedAssets
-                .filter((asset: Asset) => asset.id !== BTC_ASSET.id)
-                .map((asset: Asset) => (
-                  <Listbox.Option
-                    key={asset.id}
-                    className={({ active }) =>
-                      `${styles.listboxOption} ${active ? styles.listboxOptionActive : styles.listboxOptionInactive}`
-                    }
-                    value={asset}
-                  >
-                    {({ selected }) => (
-                      <>
-                        <span className={styles.runeOptionContent}>
-                          {isValidImageSrc(asset.imageURI) ? (
-                            <Image
-                              src={asset.imageURI}
-                              alt=""
-                              className={styles.runeImage}
-                              width={24}
-                              height={24}
-                              aria-hidden="true"
-                              onError={(e) => {
-                                const target = e.target as HTMLImageElement;
-                                if (target) {
-                                  target.style.display = "none";
-                                }
-                              }}
-                            />
-                          ) : null}
-                          <span
-                            className={`${styles.listboxOptionText} ${selected ? styles.listboxOptionTextSelected : styles.listboxOptionTextUnselected}`}
-                          >
-                            {asset.name}
-                          </span>
-                        </span>
-                        {selected && (
-                          <span className={styles.listboxOptionCheckContainer}>
-                            <CheckIcon
-                              className={styles.listboxOptionCheckIcon}
-                              aria-hidden="true"
-                            />
-                          </span>
-                        )}
-                      </>
-                    )}
-                  </Listbox.Option>
-                ))}
-            </Listbox.Options>
-          </Transition>
-        </div>
-      </Listbox>
-    </div>
+    <AssetSelectorDropdown
+      selectedAsset={selectedAsset}
+      onAssetChange={onAssetChange}
+      availableAssets={combinedAssets}
+      searchQuery={searchQuery}
+      onSearchChange={handleSearchChange}
+      disabled={disabled}
+      showBtcInSelector={showBtcInSelector}
+      isAssetsLoading={loading}
+      assetsError={error}
+      isPreselectedAssetLoading={isPreselectedAssetLoading}
+    />
   );
 };
 

--- a/src/components/AssetSelectorDropdown.tsx
+++ b/src/components/AssetSelectorDropdown.tsx
@@ -1,0 +1,259 @@
+import React, { useEffect, useState, Fragment } from "react";
+import Image from "next/image";
+import { Listbox, Transition } from "@headlessui/react";
+import { ChevronUpDownIcon, CheckIcon } from "@heroicons/react/24/solid";
+import styles from "./InputArea.module.css";
+import { Asset, BTC_ASSET } from "@/types/common";
+
+interface AssetSelectorDropdownProps {
+  selectedAsset: Asset | null;
+  onAssetChange: (asset: Asset) => void;
+  availableAssets: Asset[];
+  searchQuery: string;
+  onSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  showBtcInSelector?: boolean;
+  isAssetsLoading?: boolean;
+  assetsError?: string | null;
+  isPreselectedAssetLoading?: boolean;
+}
+
+const AssetSelectorDropdown: React.FC<AssetSelectorDropdownProps> = ({
+  selectedAsset,
+  onAssetChange,
+  availableAssets,
+  searchQuery,
+  onSearchChange,
+  disabled = false,
+  showBtcInSelector = true,
+  isAssetsLoading = false,
+  assetsError = null,
+  isPreselectedAssetLoading = false,
+}) => {
+  const [loadingDots, setLoadingDots] = useState("");
+
+  useEffect(() => {
+    const shouldAnimate = isAssetsLoading || isPreselectedAssetLoading;
+
+    if (!shouldAnimate) {
+      setLoadingDots("");
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setLoadingDots((prev) => (prev === "..." ? "" : prev + "."));
+    }, 500);
+
+    return () => clearInterval(interval);
+  }, [isAssetsLoading, isPreselectedAssetLoading]);
+
+  const isValidImageSrc = (src?: string | null): src is string => {
+    if (!src || typeof src !== "string") return false;
+    return (
+      src.startsWith("http") || src.startsWith("/") || src.startsWith("data:")
+    );
+  };
+
+  const displayedAssets = availableAssets;
+  const currentError = assetsError;
+
+  return (
+    <div className={styles.listboxContainer}>
+      <Listbox
+        value={selectedAsset}
+        onChange={onAssetChange}
+        disabled={disabled || isAssetsLoading || isPreselectedAssetLoading}
+      >
+        <div className={styles.listboxRelative}>
+          <Listbox.Button className={styles.listboxButton}>
+            <span className={styles.listboxButtonText}>
+              {isPreselectedAssetLoading ? (
+                <span className={styles.loadingText}>
+                  Loading Rune{loadingDots}
+                </span>
+              ) : (
+                <>
+                  {isValidImageSrc(selectedAsset?.imageURI) ? (
+                    <Image
+                      src={selectedAsset.imageURI!}
+                      alt={`${selectedAsset.name} logo`}
+                      className={styles.assetButtonImage}
+                      width={24}
+                      height={24}
+                      aria-hidden="true"
+                      onError={(e) => {
+                        const target = e.target as HTMLImageElement;
+                        if (target) target.style.display = "none";
+                      }}
+                    />
+                  ) : null}
+                  {isAssetsLoading
+                    ? `Loading${loadingDots}`
+                    : selectedAsset
+                      ? selectedAsset.name
+                      : "Select Asset"}
+                </>
+              )}
+            </span>
+            <span className={styles.listboxButtonIconContainer}>
+              <ChevronUpDownIcon
+                className={styles.listboxButtonIcon}
+                aria-hidden="true"
+              />
+            </span>
+          </Listbox.Button>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+          >
+            <Listbox.Options className={styles.listboxOptions}>
+              <div className={styles.searchContainer}>
+                <div className={styles.searchWrapper}>
+                  <Image
+                    src="/icons/magnifying_glass-0.png"
+                    alt="Search"
+                    className={styles.searchIconEmbedded}
+                    width={16}
+                    height={16}
+                  />
+                  <input
+                    type="text"
+                    placeholder="Search runes..."
+                    value={searchQuery}
+                    onChange={onSearchChange}
+                    className={styles.searchInput}
+                  />
+                </div>
+              </div>
+
+              {isAssetsLoading && (
+                <div className={styles.listboxLoadingOrEmpty}>
+                  Loading Runes{loadingDots}
+                </div>
+              )}
+              {!isAssetsLoading && currentError && (
+                <div
+                  className={`${styles.listboxError} ${styles.messageWithIcon}`}
+                >
+                  <Image
+                    src="/icons/msg_error-0.png"
+                    alt="Error"
+                    className={styles.messageIcon}
+                    width={16}
+                    height={16}
+                  />
+                  <span>{currentError}</span>
+                </div>
+              )}
+              {!isAssetsLoading &&
+                !currentError &&
+                displayedAssets.length === 0 && (
+                  <div className={styles.listboxLoadingOrEmpty}>
+                    {searchQuery
+                      ? "No matching runes found"
+                      : "No runes available"}
+                  </div>
+                )}
+
+              {showBtcInSelector &&
+                (searchQuery.trim() === "" ||
+                  BTC_ASSET.name
+                    .toLowerCase()
+                    .includes(searchQuery.trim().toLowerCase())) && (
+                  <Listbox.Option
+                    key={BTC_ASSET.id}
+                    className={({ active }) =>
+                      `${styles.listboxOption} ${active ? styles.listboxOptionActive : styles.listboxOptionInactive}`
+                    }
+                    value={BTC_ASSET}
+                  >
+                    {({ selected }) => (
+                      <>
+                        <span className={styles.runeOptionContent}>
+                          {isValidImageSrc(BTC_ASSET.imageURI) ? (
+                            <Image
+                              src={BTC_ASSET.imageURI}
+                              alt=""
+                              className={styles.runeImage}
+                              width={24}
+                              height={24}
+                              aria-hidden="true"
+                            />
+                          ) : null}
+                          <span
+                            className={`${styles.listboxOptionText} ${selected ? styles.listboxOptionTextSelected : styles.listboxOptionTextUnselected}`}
+                          >
+                            {BTC_ASSET.name}
+                          </span>
+                        </span>
+                        {selected && (
+                          <span className={styles.listboxOptionCheckContainer}>
+                            <CheckIcon
+                              className={styles.listboxOptionCheckIcon}
+                              aria-hidden="true"
+                            />
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </Listbox.Option>
+                )}
+
+              {displayedAssets
+                .filter((asset: Asset) => asset.id !== BTC_ASSET.id)
+                .map((asset: Asset) => (
+                  <Listbox.Option
+                    key={asset.id}
+                    className={({ active }) =>
+                      `${styles.listboxOption} ${active ? styles.listboxOptionActive : styles.listboxOptionInactive}`
+                    }
+                    value={asset}
+                  >
+                    {({ selected }) => (
+                      <>
+                        <span className={styles.runeOptionContent}>
+                          {isValidImageSrc(asset.imageURI) ? (
+                            <Image
+                              src={asset.imageURI}
+                              alt=""
+                              className={styles.runeImage}
+                              width={24}
+                              height={24}
+                              aria-hidden="true"
+                              onError={(e) => {
+                                const target = e.target as HTMLImageElement;
+                                if (target) {
+                                  target.style.display = "none";
+                                }
+                              }}
+                            />
+                          ) : null}
+                          <span
+                            className={`${styles.listboxOptionText} ${selected ? styles.listboxOptionTextSelected : styles.listboxOptionTextUnselected}`}
+                          >
+                            {asset.name}
+                          </span>
+                        </span>
+                        {selected && (
+                          <span className={styles.listboxOptionCheckContainer}>
+                            <CheckIcon
+                              className={styles.listboxOptionCheckIcon}
+                              aria-hidden="true"
+                            />
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </Listbox.Option>
+                ))}
+            </Listbox.Options>
+          </Transition>
+        </div>
+      </Listbox>
+    </div>
+  );
+};
+
+export default AssetSelectorDropdown;

--- a/src/hooks/useAssetSearch.ts
+++ b/src/hooks/useAssetSearch.ts
@@ -1,0 +1,120 @@
+import { useState, useEffect, useMemo } from "react";
+import debounce from "lodash.debounce";
+import { fetchRunesFromApi, fetchPopularFromApi } from "@/lib/apiClient";
+import type { Rune } from "@/types/satsTerminal";
+import { Asset } from "@/types/common";
+
+interface UseAssetSearchResult {
+  searchQuery: string;
+  handleSearchChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  availableAssets: Asset[];
+  isLoadingAssets: boolean;
+  currentError: string | null;
+}
+
+export default function useAssetSearch(): UseAssetSearchResult {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isSearching, setIsSearching] = useState(false);
+  const [searchResults, setSearchResults] = useState<Asset[]>([]);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  const [popularRunes, setPopularRunes] = useState<Asset[]>([]);
+  const [isPopularLoading, setIsPopularLoading] = useState(false);
+  const [popularError, setPopularError] = useState<string | null>(null);
+
+  // Load popular runes once on mount
+  useEffect(() => {
+    const loadPopular = async () => {
+      setIsPopularLoading(true);
+      setPopularError(null);
+      try {
+        const response = await fetchPopularFromApi();
+        if (Array.isArray(response)) {
+          const mapped: Asset[] = response.map(
+            (collection: Record<string, unknown>) => ({
+              id:
+                (collection?.rune as string) ||
+                (collection?.rune_id as string) ||
+                `unknown_${Math.random()}`,
+              name:
+                ((collection?.etching as Record<string, unknown>)
+                  ?.runeName as string) ||
+                (collection?.rune as string) ||
+                (collection?.slug as string)?.replace(/-/g, "•") ||
+                "Unknown",
+              imageURI:
+                (collection?.icon_content_url_data as string) ||
+                (collection?.imageURI as string),
+              isBTC: false,
+            }),
+          );
+          setPopularRunes(mapped);
+        } else {
+          setPopularRunes([]);
+        }
+      } catch (error) {
+        setPopularError(
+          error instanceof Error
+            ? error.message
+            : "Failed to fetch popular runes",
+        );
+        setPopularRunes([]);
+      } finally {
+        setIsPopularLoading(false);
+      }
+    };
+    loadPopular();
+  }, []);
+
+  const debouncedSearch = useMemo(
+    () =>
+      debounce(async (query: string) => {
+        if (!query) {
+          setSearchResults([]);
+          setIsSearching(false);
+          setSearchError(null);
+          return;
+        }
+        setIsSearching(true);
+        setSearchError(null);
+        try {
+          const results: Rune[] = await fetchRunesFromApi(query);
+          const mappedResults: Asset[] = results.map((rune) => ({
+            id: rune.id,
+            name: rune.name,
+            imageURI: rune.imageURI,
+            isBTC: false,
+          }));
+          setSearchResults(mappedResults);
+        } catch (error: unknown) {
+          setSearchError(
+            error instanceof Error ? error.message : "Failed to search",
+          );
+          setSearchResults([]);
+        } finally {
+          setIsSearching(false);
+        }
+      }, 300),
+    [],
+  );
+
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const query = e.target.value;
+    setSearchQuery(query);
+    debouncedSearch(query);
+  };
+
+  const displayedAssets = searchQuery.trim() ? searchResults : popularRunes;
+  const isLoadingAssets = searchQuery.trim() ? isSearching : isPopularLoading;
+  const currentError = searchQuery.trim() ? searchError : popularError;
+
+  return {
+    searchQuery,
+    handleSearchChange,
+    availableAssets: displayedAssets,
+    isLoadingAssets,
+    currentError,
+  };
+}


### PR DESCRIPTION
## Summary
- create `useAssetSearch` hook handling asset search and popular rune loading
- move dropdown UI to new `AssetSelectorDropdown`
- refactor `AssetSelector` to compose the hook and dropdown
- document the split in `AGENTS.md`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify the internal structure and separation of logic within the asset selector component.

- **New Features**
  - Introduced a new dropdown component for asset selection with enhanced search functionality.
  - Added a custom hook to manage asset search state, including debounced input and loading indicators.

- **Refactor**
  - Simplified the asset selector by delegating search logic and UI rendering to dedicated components and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->