### PR TITLE
Fix footer button outline style

### DIFF
--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -30,6 +30,5 @@
 }
 
 .root:focus {
-  outline: 2px dotted var(--win98-blue);
-  outline-offset: 2px;
+  outline: 1px solid var(--win98-blue);
 }


### PR DESCRIPTION
## Summary
- remove dotted focus outline in `Button.module.css`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
