### PR TITLE
Improve test coverage

### DIFF
--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,6 +5,8 @@ const config: Config = {
   testEnvironment: "node", // Assuming node environment for now, can be changed later if needed for UI tests
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^.+\\.module\\.(css|scss)$": "identity-obj-proxy",
+    "^.+\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
   },
 };
 

--- a/src/app/api/ordiscan/rune-info/route.test.ts
+++ b/src/app/api/ordiscan/rune-info/route.test.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from "next/server";
+import { GET } from "./route";
+import { getRuneData } from "@/lib/runesData";
+
+jest.mock("@/lib/runesData");
+
+describe("rune info route", () => {
+  it("returns rune info when found", async () => {
+    (getRuneData as jest.Mock).mockResolvedValue({ name: "BTC" });
+    const request = new NextRequest("https://example.com/api?name=BTC");
+    const response = await GET(request);
+    expect(getRuneData).toHaveBeenCalledWith("BTC");
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: { name: "BTC" },
+    });
+  });
+
+  it("returns 404 success when rune not found", async () => {
+    (getRuneData as jest.Mock).mockResolvedValue(null);
+    const request = new NextRequest("https://example.com/api?name=UNKNOWN");
+    const response = await GET(request);
+    expect(getRuneData).toHaveBeenCalledWith("UNKNOWN");
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      data: null,
+    });
+  });
+});

--- a/src/lib/api/ordiscan.test.ts
+++ b/src/lib/api/ordiscan.test.ts
@@ -1,0 +1,34 @@
+import { fetchRuneInfoFromApi } from "./ordiscan";
+
+beforeEach(() => {
+  (global.fetch as unknown as jest.Mock) = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe("fetchRuneInfoFromApi", () => {
+  it("fetches and returns rune info", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ success: true, data: { name: "BTC" } }),
+    });
+
+    const result = await fetchRuneInfoFromApi("BTC");
+    expect(fetch).toHaveBeenCalledWith("/api/ordiscan/rune-info?name=BTC");
+    expect(result).toEqual({ name: "BTC" });
+  });
+
+  it("throws on error response", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "oops",
+      json: () => Promise.resolve({ error: "fail" }),
+    });
+
+    await expect(fetchRuneInfoFromApi("FAIL")).rejects.toThrow("fail");
+  });
+});

--- a/src/store/runesInfoStore.test.ts
+++ b/src/store/runesInfoStore.test.ts
@@ -1,0 +1,14 @@
+import { useRunesInfoStore } from "./runesInfoStore";
+
+describe("runesInfoStore", () => {
+  it("updates selected rune info", () => {
+    const info: { name: string } = { name: "BTC" };
+    useRunesInfoStore.getState().setSelectedRuneInfo(info);
+    expect(useRunesInfoStore.getState().selectedRuneInfo).toBe(info);
+  });
+
+  it("updates search query", () => {
+    useRunesInfoStore.getState().setRuneSearchQuery("test");
+    expect(useRunesInfoStore.getState().runeSearchQuery).toBe("test");
+  });
+});


### PR DESCRIPTION
## Summary
- map CSS modules in Jest
- add tests for the rune-info API route
- add tests for Ordiscan API helpers
- add tests for Zustand runes info store

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Added new tests for API routes, API data fetching, and state management to improve reliability and coverage.
- **Chores**
	- Updated testing configuration to better handle style imports during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->