### PR TITLE
Remove unused clsx dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@tanstack/react-query": "^5.70.0",
     "@types/lodash.debounce": "^4.0.9",
     "@vercel/analytics": "^1.5.0",
-    "clsx": "^2.1.1",
     "lodash.debounce": "^4.0.8",
     "next": "15.2.4",
     "ordiscan": "^1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,9 +29,6 @@ importers:
       '@vercel/analytics':
         specifier: ^1.5.0
         version: 1.5.0(next@15.2.4(@babel/core@7.27.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
       lodash.debounce:
         specifier: ^4.0.8
         version: 4.0.8


### PR DESCRIPTION
## Summary
- clean up `package.json` and `pnpm-lock.yaml`
- remove `clsx` package as it isn't used

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`

`pnpm install` failed due to network restrictions, so the lock file was edited manually.