### PR TITLE
Fix swap order side case

### DIFF
--- a/src/hooks/useSwapExecution.ts
+++ b/src/hooks/useSwapExecution.ts
@@ -132,7 +132,7 @@ export default function useSwapExecution({
         if ("side" in order && order.side)
           (patchedOrder as Record<string, unknown>)["side"] = String(
             order.side,
-          ).toLowerCase() as "buy" | "sell";
+          ).toUpperCase() as "BUY" | "SELL";
         return patchedOrder as RuneOrder;
       });
 
@@ -291,7 +291,7 @@ export default function useSwapExecution({
               if ("side" in order && order.side)
                 (patchedOrder as Record<string, unknown>)["side"] = String(
                   order.side,
-                ).toLowerCase() as "buy" | "sell";
+                ).toUpperCase() as "BUY" | "SELL";
               return patchedOrder as RuneOrder;
             },
           );


### PR DESCRIPTION
## Summary
- send `order.side` in uppercase when generating a PSBT

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
