### PR TITLE
Handle missing onAssetChange

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,9 +3,14 @@ import type { Config } from "jest";
 const config: Config = {
   preset: "ts-jest",
   testEnvironment: "node", // Assuming node environment for now, can be changed later if needed for UI tests
+  globals: {
+    "ts-jest": {
+      tsconfig: "tsconfig.jest.json",
+    },
+  },
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
-    "^.+\\.module\\.(css|scss)$": "identity-obj-proxy",
+    "^.+\\.module\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
     "^.+\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js",
   },
 };

--- a/src/components/InputArea.test.tsx
+++ b/src/components/InputArea.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * @jest-environment node
+ */
+
+import React from "react";
+import { renderToString } from "react-dom/server";
+import InputArea from "./InputArea";
+import { BTC_ASSET } from "@/types/common";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) =>
+    React.createElement("img", props),
+}));
+
+describe("InputArea", () => {
+  it("renders with assetSelectorEnabled and no onAssetChange", () => {
+    expect(() => {
+      renderToString(
+        React.createElement(InputArea, {
+          label: "Label",
+          inputId: "input",
+          inputValue: "",
+          assetSelectorEnabled: true,
+          selectedAsset: BTC_ASSET,
+          availableAssets: [BTC_ASSET],
+        }),
+      );
+    }).not.toThrow();
+  });
+});

--- a/src/components/InputArea.tsx
+++ b/src/components/InputArea.tsx
@@ -95,7 +95,7 @@ export const InputArea: React.FC<InputAreaProps> = ({
       {assetSelectorEnabled ? (
         <AssetSelector
           selectedAsset={selectedAsset}
-          onAssetChange={onAssetChange!}
+          onAssetChange={onAssetChange ?? (() => {})}
           availableAssets={availableAssets}
           disabled={disabled}
           showBtcInSelector={showBtcInSelector}

--- a/tsconfig.jest.json
+++ b/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Summary
- remove non-null assertion in `InputArea`
- use default noop callback when `onAssetChange` is undefined
- enable JSX compilation for Jest and adjust module mapping
- add regression test for optional `onAssetChange`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`