### PR TITLE
Fix swap error handling

### DIFF
--- a/src/components/swap/SwapProcessManager.tsx
+++ b/src/components/swap/SwapProcessManager.tsx
@@ -39,7 +39,8 @@ export function swapProcessReducer(
 ): SwapProcessState {
   // Log actions that contain errors or significant state changes
   if (action.type === "SWAP_ERROR" || action.type === "FETCH_QUOTE_ERROR") {
-    console.error(`SwapProcess: ${action.type}`, action);
+    // Use warn to avoid triggering Next.js error overlay while still logging
+    console.warn(`SwapProcess: ${action.type}`, action);
   }
   switch (action.type) {
     case "RESET_SWAP":


### PR DESCRIPTION
## Summary
- avoid triggering Next.js overlay when logging swap errors
- keep error step active so message remains visible

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
