### PR TITLE
Fix borrow range decimals

### DIFF
--- a/src/hooks/useBorrowQuotes.ts
+++ b/src/hooks/useBorrowQuotes.ts
@@ -97,7 +97,12 @@ export function useBorrowQuotes({
   // Fetch min-max borrow range when collateral asset changes
   useEffect(() => {
     const fetchMinMaxRange = async () => {
-      if (!collateralAsset || !address || collateralAsset.isBTC) {
+      if (
+        !collateralAsset ||
+        !address ||
+        collateralAsset.isBTC ||
+        !collateralRuneInfo
+      ) {
         setMinMaxRange(null);
         setBorrowRangeError(null);
         return;


### PR DESCRIPTION
## Summary
- wait for rune data to load before requesting borrow ranges

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`