### PR TITLE
Integrate 98.css on key buttons

### DIFF
--- a/src/components/ConnectWalletButton.module.css
+++ b/src/components/ConnectWalletButton.module.css
@@ -2,16 +2,8 @@
 
 .connectButton {
   padding: var(--space-1) var(--space-2);
-  background-color: var(--win98-gray);
-  border: var(--win98-border-outset);
-  border-color: var(--win98-border-outset-colors);
   font-size: var(--font-size-normal);
   line-height: 1.25rem;
-  color: var(--win98-black);
-}
-
-.connectButton:active {
-  border-color: var(--win98-border-inset-colors);
 }
 
 .buttonContainer {

--- a/src/components/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import "98.css";
 import styles from "./ConnectWalletButton.module.css";
 import {
   useWalletConnection,
@@ -38,7 +39,10 @@ export function ConnectWalletButton() {
         <span className={styles.connectedText}>
           {connectedWalletName}: {truncateAddress(address)}
         </span>
-        <button onClick={handleDisconnect} className={styles.connectButton}>
+        <button
+          onClick={handleDisconnect}
+          className={`button ${styles.connectButton}`}
+        >
           Disconnect
         </button>
       </div>
@@ -47,7 +51,7 @@ export function ConnectWalletButton() {
 
   if (isConnecting) {
     return (
-      <button className={styles.connectButton} disabled>
+      <button className={`button ${styles.connectButton}`} disabled>
         Connecting...
       </button>
     );
@@ -57,7 +61,7 @@ export function ConnectWalletButton() {
     <div className={styles.connectContainer} ref={dropdownRef}>
       <button
         onClick={toggleDropdown}
-        className={styles.connectButton}
+        className={`button ${styles.connectButton}`}
         disabled={isConnecting}
       >
         Connect Wallet

--- a/src/components/swap/SwapButton.module.css
+++ b/src/components/swap/SwapButton.module.css
@@ -1,26 +1,6 @@
 /* SwapButton Component Styles */
 
-.baseButton {
-  padding: var(--space-2) var(--space-4);
-  background-color: var(--win98-gray);
-  color: var(--win98-black);
-  cursor: pointer;
-  border: var(--win98-border-outset);
-  border-color: var(--win98-border-outset-colors);
-}
-
-.baseButton:active {
-  border-color: var(--win98-border-inset-colors);
-}
-
-.baseButton:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-  color: var(--win98-dark-gray);
-}
-
 .swapButton {
-  composes: baseButton; /* Inherit base button styles */
   width: 100%;
   font-weight: 700;
 }

--- a/src/components/swap/SwapButton.tsx
+++ b/src/components/swap/SwapButton.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import "98.css";
 import styles from "./SwapButton.module.css";
 import { Asset } from "@/types/common";
 import { type QuoteResponse } from "satsterminal-sdk";
@@ -186,7 +187,7 @@ export const SwapButton: React.FC<SwapButtonProps> = ({
 
   return (
     <button
-      className={styles.swapButton}
+      className={`button ${styles.swapButton}`}
       onClick={handleClick}
       disabled={isDisabled}
     >


### PR DESCRIPTION
## Summary
- revert layout and footer changes
- restore Button component styling
- apply 98.css only to ConnectWalletButton and SwapButton

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
