### PR TITLE
Fix next.js image remote pattern

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,8 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: 'https',
-        hostname: '**',
+        // allow images from any https domain
+        hostname: '*.*',
       },
     ],
   },


### PR DESCRIPTION
## Summary
- restrict `next.config.ts` image remote patterns to a valid glob

## Testing
- `pnpm test`
- `pnpm lint`
- `next build` *(from pre-commit)*