### PR TITLE
Add mempool-based fee selector

### DIFF
--- a/src/components/BorrowTab.tsx
+++ b/src/components/BorrowTab.tsx
@@ -9,6 +9,7 @@ import Button from "./Button";
 import CollateralInput from "./CollateralInput";
 import BorrowQuotesList from "./BorrowQuotesList";
 import BorrowSuccessMessage from "./BorrowSuccessMessage";
+import FeeSelector from "./FeeSelector";
 import { Asset } from "@/types/common";
 import { FormattedRuneAmount } from "./FormattedRuneAmount";
 import { useBorrowProcess } from "@/hooks/useBorrowProcess";
@@ -59,6 +60,7 @@ export function BorrowTab({
   const router = useRouter();
   const [collateralAsset, setCollateralAsset] = useState<Asset | null>(null);
   const [collateralAmount, setCollateralAmount] = useState("");
+  const [feeRate, setFeeRate] = useState(0);
 
   const { data: runeBalances, isLoading: isRuneBalancesLoading } = useQuery<
     OrdiscanRuneBalance[],
@@ -221,6 +223,8 @@ export function BorrowTab({
         }}
       />
 
+      <FeeSelector onChange={setFeeRate} />
+
       {borrowRangeError && (
         <div className="errorText" style={{ marginBottom: 8 }}>
           {borrowRangeError}
@@ -242,7 +246,7 @@ export function BorrowTab({
 
       {selectedQuoteId && (
         <Button
-          onClick={() => startLoan(selectedQuoteId, collateralAmount)}
+          onClick={() => startLoan(selectedQuoteId, collateralAmount, feeRate)}
           disabled={!canStartLoan}
         >
           {isPreparing

--- a/src/components/FeeSelector.module.css
+++ b/src/components/FeeSelector.module.css
@@ -1,0 +1,31 @@
+.container {
+  margin-top: var(--space-2);
+}
+
+.buttonRow {
+  display: flex;
+  gap: var(--space-1);
+  margin-bottom: var(--space-1);
+}
+
+.feeButton {
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-small);
+  background-color: var(--win98-gray);
+  color: var(--win98-black);
+  border: var(--win98-border-outset);
+  border-color: var(--win98-border-outset-colors);
+}
+
+.feeButton:active {
+  border-color: var(--win98-border-inset-colors);
+}
+
+.feeButtonActive {
+  border: var(--win98-border-inset);
+  border-color: var(--win98-border-inset-colors);
+}
+
+.customInput {
+  width: 80px;
+}

--- a/src/components/FeeSelector.tsx
+++ b/src/components/FeeSelector.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useState } from "react";
+import styles from "./FeeSelector.module.css";
+import useFeeRates from "@/hooks/useFeeRates";
+
+export type FeeOption = "slow" | "medium" | "fast" | "custom";
+
+interface FeeSelectorProps {
+  onChange: (rate: number) => void;
+}
+
+const FeeSelector: React.FC<FeeSelectorProps> = ({ onChange }) => {
+  const { data: fees } = useFeeRates();
+  const [option, setOption] = useState<FeeOption>("medium");
+  const [custom, setCustom] = useState("");
+
+  const low = fees?.hourFee ?? 1;
+  const medium = fees?.halfHourFee ?? low;
+  const high = fees?.fastestFee ?? medium;
+
+  useEffect(() => {
+    if (!fees) return;
+    let rate = medium;
+    if (option === "slow") rate = low;
+    else if (option === "fast") rate = high;
+    else if (option === "custom")
+      rate = Math.max(parseFloat(custom) || low, low);
+    onChange(rate);
+  }, [option, custom, fees, onChange]);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.buttonRow}>
+        <button
+          className={`${styles.feeButton} ${option === "slow" ? styles.feeButtonActive : ""}`}
+          onClick={() => setOption("slow")}
+        >
+          Slow ({low} sats/vb)
+        </button>
+        <button
+          className={`${styles.feeButton} ${option === "medium" ? styles.feeButtonActive : ""}`}
+          onClick={() => setOption("medium")}
+        >
+          Medium ({medium} sats/vb)
+        </button>
+        <button
+          className={`${styles.feeButton} ${option === "fast" ? styles.feeButtonActive : ""}`}
+          onClick={() => setOption("fast")}
+        >
+          Fast ({high} sats/vb)
+        </button>
+        <button
+          className={`${styles.feeButton} ${option === "custom" ? styles.feeButtonActive : ""}`}
+          onClick={() => setOption("custom")}
+        >
+          Custom
+        </button>
+      </div>
+      {option === "custom" && (
+        <input
+          className={styles.customInput}
+          type="number"
+          min={low}
+          value={custom}
+          onChange={(e) => setCustom(e.target.value)}
+          placeholder={`${low}+`}
+        />
+      )}
+    </div>
+  );
+};
+
+export default FeeSelector;

--- a/src/components/SwapTab.tsx
+++ b/src/components/SwapTab.tsx
@@ -23,6 +23,7 @@ import { type RuneData } from "@/lib/runesData";
 import { SwapTabForm, useSwapProcessManager } from "./swap";
 import useSwapExecution from "@/hooks/useSwapExecution";
 import useUsdValues from "@/hooks/useUsdValues";
+import FeeSelector from "./FeeSelector";
 
 // Mock address for fetching quotes when disconnected
 const MOCK_ADDRESS = "34xp4vRoCGJym3xR7yCVPFHoCNxv4Twseo";
@@ -74,6 +75,7 @@ export function SwapTab({
   // State for input/output amounts
   const [inputAmount, setInputAmount] = useState("");
   const [outputAmount, setOutputAmount] = useState("");
+  const [feeRate, setFeeRate] = useState(0);
 
   // State for selected assets
   const [assetIn, setAssetIn] = useState<Asset>(BTC_ASSET);
@@ -546,6 +548,7 @@ export function SwapTab({
     dispatchSwap,
     isThrottledRef,
     quoteKeyRef,
+    selectedFeeRate: feeRate,
   });
 
   // Single useEffect for handling debounced input changes
@@ -772,6 +775,7 @@ export function SwapTab({
       showPriceChart={showPriceChart}
       onShowPriceChart={onShowPriceChart}
       isPreselectedRuneLoading={isPreselectedRuneLoading}
+      feeSelector={<FeeSelector onChange={setFeeRate} />}
     />
   );
 }

--- a/src/components/swap/SwapTabForm.tsx
+++ b/src/components/swap/SwapTabForm.tsx
@@ -44,6 +44,7 @@ interface SwapTabFormProps {
   showPriceChart: boolean;
   onShowPriceChart?: (assetName?: string, shouldToggle?: boolean) => void;
   isPreselectedRuneLoading: boolean;
+  feeSelector: React.ReactNode;
 }
 
 export default function SwapTabForm({
@@ -79,6 +80,7 @@ export default function SwapTabForm({
   showPriceChart,
   onShowPriceChart,
   isPreselectedRuneLoading,
+  feeSelector,
 }: SwapTabFormProps) {
   return (
     <div className={styles.swapTabContainer}>
@@ -148,6 +150,7 @@ export default function SwapTabForm({
         showPriceChart={showPriceChart}
         onShowPriceChart={onShowPriceChart}
       />
+      {feeSelector}
       <SwapButton
         connected={connected}
         assetIn={assetIn}

--- a/src/hooks/useBorrowProcess.ts
+++ b/src/hooks/useBorrowProcess.ts
@@ -37,6 +37,7 @@ export function useBorrowProcess({
   const startLoan = async (
     selectedQuoteId: string | null,
     collateralAmount: string,
+    feeRate: number,
   ) => {
     const parsed = Number(collateralAmount);
     if (
@@ -69,7 +70,6 @@ export function useBorrowProcess({
         );
       }
 
-      const feeRate = 5;
       const prepareResult: LiquidiumPrepareBorrowResponse =
         await prepareLiquidiumBorrow({
           instant_offer_id: selectedQuoteId,

--- a/src/hooks/useFeeRates.ts
+++ b/src/hooks/useFeeRates.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchRecommendedFeeRates, QUERY_KEYS } from "@/lib/api";
+
+export const useFeeRates = () =>
+  useQuery({
+    queryKey: [QUERY_KEYS.BTC_FEE_RATES],
+    queryFn: fetchRecommendedFeeRates,
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
+  });
+
+export default useFeeRates;

--- a/src/hooks/useSwapExecution.ts
+++ b/src/hooks/useSwapExecution.ts
@@ -39,6 +39,7 @@ interface UseSwapExecutionArgs {
   dispatchSwap: React.Dispatch<SwapProcessAction>;
   isThrottledRef: React.MutableRefObject<boolean>;
   quoteKeyRef: React.MutableRefObject<string>;
+  selectedFeeRate?: number;
 }
 
 export default function useSwapExecution({
@@ -56,6 +57,7 @@ export default function useSwapExecution({
   dispatchSwap,
   isThrottledRef,
   quoteKeyRef,
+  selectedFeeRate,
 }: UseSwapExecutionArgs) {
   const errorMessageRef = useRef<string | null>(null);
 
@@ -138,11 +140,14 @@ export default function useSwapExecution({
 
       // Get the optimal fee rate from the mempool.space API, falling back to defaults
       // Use appropriate fee rate based on transaction type (higher for selling runes)
-      const optimalFeeRate = recommendedFeeRates
-        ? !isBtcToRune
-          ? recommendedFeeRates.fastestFee // Use fastest fee for selling runes (higher priority)
-          : recommendedFeeRates.halfHourFee // Use half-hour fee for buying runes (medium priority)
-        : 15; // Fallback if API data isn't available
+      const optimalFeeRate =
+        selectedFeeRate && selectedFeeRate > 0
+          ? selectedFeeRate
+          : recommendedFeeRates
+            ? !isBtcToRune
+              ? recommendedFeeRates.fastestFee
+              : recommendedFeeRates.halfHourFee
+            : 15;
 
       const psbtParams: GetPSBTParams = {
         orders: orders,


### PR DESCRIPTION
## Summary
- implement `FeeSelector` with slow, medium, fast and custom fees
- fetch recommended fees via new `useFeeRates` hook
- integrate selector into Swap and Borrow flows
- pass selected fee rate to swap and borrow processes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`
