### PR TITLE
Add borrow quotes hook tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@commitlint/cli": "^19.8.0",
     "@commitlint/config-conventional": "^19.8.0",
     "@eslint/eslintrc": "^3",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.14",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3
         version: 3.3.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -1401,6 +1404,25 @@ packages:
   '@tanstack/virtual-core@3.13.6':
     resolution: {integrity: sha512-cnQUeWnhNP8tJ4WsGcYiX24Gjkc9ALstLbHcBj1t3E7EimN6n6kHH+DPV4PpDnuw00NApQp+ViojMj1GRdwYQg==}
 
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -1415,6 +1437,9 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1893,6 +1918,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
@@ -2458,6 +2486,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -3612,6 +3643,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -4085,6 +4120,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4123,6 +4162,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -6262,6 +6304,27 @@ snapshots:
 
   '@tanstack/virtual-core@3.13.6': {}
 
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.27.0
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.27.0
+      '@testing-library/dom': 10.4.0
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.1
+      '@types/react-dom': 19.1.2(@types/react@19.1.1)
+
   '@tsconfig/node10@1.0.11': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -6274,6 +6337,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6710,6 +6775,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.2: {}
 
@@ -7314,6 +7383,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -8888,6 +8959,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lz-string@1.5.0: {}
+
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.1
@@ -9539,6 +9612,12 @@ snapshots:
 
   prettier@3.5.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -9574,6 +9653,8 @@ snapshots:
       scheduler: 0.26.0
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@18.3.1: {}
 

--- a/src/hooks/useBorrowQuotes.test.tsx
+++ b/src/hooks/useBorrowQuotes.test.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { JSDOM } from 'jsdom';
+import type { RuneData } from '@/lib/runesData';
+import useBorrowQuotes from './useBorrowQuotes';
+
+jest.mock('@/lib/apiClient', () => ({
+  fetchBorrowQuotesFromApi: jest.fn(),
+  fetchBorrowRangesFromApi: jest.fn(),
+  fetchPopularFromApi: jest.fn(),
+}));
+
+const {
+  fetchBorrowQuotesFromApi,
+  fetchBorrowRangesFromApi,
+  fetchPopularFromApi,
+} = jest.requireMock('@/lib/apiClient');
+
+beforeAll(() => {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>');
+  (global as unknown as { window: Window }).window =
+    dom.window as unknown as Window;
+  (global as unknown as { document: Document }).document = dom.window.document;
+});
+
+afterAll(() => {
+  (
+    global as unknown as { window: Window & { close: () => void } }
+  ).window.close();
+});
+
+type HookProps = Parameters<typeof useBorrowQuotes>[0];
+
+function baseProps(overrides: Partial<HookProps> = {}): HookProps {
+  return {
+    collateralAsset: null,
+    collateralAmount: '',
+    address: null,
+    collateralRuneInfo: null,
+    ...overrides,
+  };
+}
+
+describe('useBorrowQuotes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads popular runes on mount', async () => {
+    (fetchPopularFromApi as jest.Mock).mockResolvedValue([
+      { rune_id: 'AAA', slug: 'AAA', icon_content_url_data: 'a.png' },
+    ]);
+
+    const { result } = renderHook(
+      (props: HookProps) => useBorrowQuotes(props),
+      {
+        initialProps: baseProps(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isPopularLoading).toBe(false));
+    expect(fetchPopularFromApi).toHaveBeenCalled();
+    expect(result.current.popularRunes.map((r) => r.id)).toEqual([
+      'liquidiumtoken',
+      'AAA',
+    ]);
+  });
+
+  it('updates borrow range when collateral changes', async () => {
+    (fetchPopularFromApi as jest.Mock).mockResolvedValue([]);
+    (fetchBorrowRangesFromApi as jest.Mock).mockResolvedValue({
+      success: true,
+      data: {
+        runeId: 'AAA',
+        minAmount: '100',
+        maxAmount: '1000',
+        cached: false,
+        updatedAt: '',
+      },
+    });
+
+    const asset = { id: 'AAA', name: 'AAA', imageURI: 'a.png', isBTC: false };
+    const runeInfo = { id: 'AAA', name: 'AAA', decimals: 2 } as RuneData;
+
+    const { result, rerender } = renderHook(
+      (props: HookProps) => useBorrowQuotes(props),
+      {
+        initialProps: baseProps(),
+      },
+    );
+
+    rerender(
+      baseProps({
+        collateralAsset: asset,
+        address: 'addr',
+        collateralRuneInfo: runeInfo,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.minMaxRange).toBe('Min: 1.00 - Max: 10.00'),
+    );
+    expect(fetchBorrowRangesFromApi).toHaveBeenCalledWith('AAA', 'addr');
+    expect(result.current.borrowRangeError).toBeNull();
+  });
+
+  it('retrieves quotes successfully', async () => {
+    (fetchPopularFromApi as jest.Mock).mockResolvedValue([]);
+    (fetchBorrowQuotesFromApi as jest.Mock).mockResolvedValue({
+      success: true,
+      runeDetails: {
+        valid_ranges: {
+          rune_amount: { ranges: [{ min: '200', max: '2000' }] },
+          loan_term_days: [7],
+        },
+        offers: [
+          {
+            offer_id: '1',
+            fungible_amount: 1,
+            loan_term_days: 7,
+            ltv_rate: 80,
+            loan_breakdown: {
+              total_repayment_sats: 1000,
+              principal_sats: 900,
+              interest_sats: 100,
+              loan_due_by_date: '',
+              activation_fee_sats: 0,
+              discount: { discount_rate: 0, discount_sats: 0 },
+            },
+          },
+        ],
+      },
+    });
+
+    const asset = { id: 'AAA', name: 'AAA', imageURI: 'a.png', isBTC: false };
+    const runeInfo = { id: 'AAA', name: 'AAA', decimals: 2 } as RuneData;
+
+    const { result } = renderHook(
+      (props: HookProps) => useBorrowQuotes(props),
+      {
+        initialProps: baseProps({
+          collateralAsset: asset,
+          collateralAmount: '2',
+          address: 'addr',
+          collateralRuneInfo: runeInfo,
+        }),
+      },
+    );
+
+    await act(async () => {
+      await result.current.handleGetQuotes();
+    });
+
+    await waitFor(() => expect(result.current.isQuotesLoading).toBe(false));
+    expect(fetchBorrowQuotesFromApi).toHaveBeenCalledWith('AAA', '200', 'addr');
+    expect(result.current.quotes.length).toBe(1);
+    expect(result.current.minMaxRange).toBe('Min: 2.00 - Max: 20.00');
+    expect(result.current.quotesError).toBeNull();
+  });
+
+  it('handles quote API errors', async () => {
+    (fetchPopularFromApi as jest.Mock).mockResolvedValue([]);
+    (fetchBorrowQuotesFromApi as jest.Mock).mockRejectedValue(
+      new Error('fail'),
+    );
+
+    const asset = { id: 'AAA', name: 'AAA', imageURI: 'a.png', isBTC: false };
+    const runeInfo = { id: 'AAA', name: 'AAA', decimals: 2 } as RuneData;
+
+    const { result } = renderHook(
+      (props: HookProps) => useBorrowQuotes(props),
+      {
+        initialProps: baseProps({
+          collateralAsset: asset,
+          collateralAmount: '2',
+          address: 'addr',
+          collateralRuneInfo: runeInfo,
+        }),
+      },
+    );
+
+    await act(async () => {
+      await result.current.handleGetQuotes();
+    });
+
+    await waitFor(() => expect(result.current.isQuotesLoading).toBe(false));
+    expect(result.current.quotes).toEqual([]);
+    expect(result.current.quotesError).toBe('fail');
+    expect(result.current.minMaxRange).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add `@testing-library/react` dev dependency
- test `useBorrowQuotes` popular rune loading, borrow range calculations, quote retrieval and error states

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_b_685884c48a3883278f42048465a0a231