### PR TITLE
Fix BigInt precision issues in rune amount calculations

### DIFF
--- a/src/components/FormattedRuneAmount.tsx
+++ b/src/components/FormattedRuneAmount.tsx
@@ -73,7 +73,7 @@ export function FormattedRuneAmount({
   try {
     // Use BigInt for precision with large numbers before converting to Number for division
     const rawAmountBigInt = BigInt(rawAmount);
-    const divisor = BigInt(10 ** decimals);
+    const divisor = BigInt(10) ** BigInt(decimals);
 
     // Perform division carefully to handle potential floating point issues
     // For display, Number should be sufficient after scaling down

--- a/src/hooks/useBorrowQuotes.ts
+++ b/src/hooks/useBorrowQuotes.ts
@@ -149,12 +149,13 @@ export function useBorrowQuotes({
   const formatRuneAmount = (rawAmount: string, decimals: number): string => {
     try {
       const rawAmountBigInt = BigInt(rawAmount);
-      const divisorBigInt = BigInt(10 ** decimals);
+      const divisorBigInt = BigInt(10) ** BigInt(decimals);
       const scaledAmount = (rawAmountBigInt * BigInt(100)) / divisorBigInt;
       const scaledNumber = Number(scaledAmount) / 100;
       return scaledNumber.toFixed(decimals > 0 ? 2 : 0);
     } catch {
-      return (Number(rawAmount) / 10 ** decimals).toFixed(decimals > 0 ? 2 : 0);
+      const divisor = Number(BigInt(10) ** BigInt(decimals));
+      return (Number(rawAmount) / divisor).toFixed(decimals > 0 ? 2 : 0);
     }
   };
 
@@ -204,7 +205,7 @@ export function useBorrowQuotes({
           const amountInteger = Math.floor(
             amountFloat * 10 ** Math.min(8, decimals),
           );
-          const multiplier = BigInt(10 ** Math.max(0, decimals - 8));
+          const multiplier = BigInt(10) ** BigInt(Math.max(0, decimals - 8));
           const amountBigInt = BigInt(amountInteger) * multiplier;
           rawAmount = amountBigInt.toString();
         }


### PR DESCRIPTION
## Summary
- correct BigInt scaling in `useBorrowQuotes`
- correct divisor calculation in `FormattedRuneAmount`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_685ebb362ffc8327bb83b89df9f2d844

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy when displaying and calculating large numbers by updating how exponentiation is handled, ensuring correct formatting and conversion for amounts with many decimal places.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->