### PR TITLE
Fix Ordiscan 404 handling

### DIFF
--- a/src/lib/api/ordiscan.ts
+++ b/src/lib/api/ordiscan.ts
@@ -94,15 +94,15 @@ export const updateRuneDataViaApi = async (
   } catch {
     throw new Error(`Failed to parse update response for ${name}`);
   }
+  if (response.status === 404) {
+    return null;
+  }
   if (!response.ok) {
     throw new Error(
       data?.error?.message ||
         data?.error ||
         `Failed to update rune data: ${response.statusText}`,
     );
-  }
-  if (response.status === 404) {
-    return null;
   }
   return handleApiResponse<RuneData | null>(data, false);
 };
@@ -120,15 +120,15 @@ export const fetchRuneMarketFromApi = async (
   } catch {
     throw new Error(`Failed to parse market info for ${name}`);
   }
+  if (response.status === 404) {
+    return null;
+  }
   if (!response.ok) {
     throw new Error(
       data?.error?.message ||
         data?.error ||
         `Failed to fetch market info: ${response.statusText}`,
     );
-  }
-  if (response.status === 404) {
-    return null;
   }
   return handleApiResponse<OrdiscanRuneMarketInfo | null>(data, false);
 };


### PR DESCRIPTION
## Summary
- ensure `updateRuneDataViaApi` and `fetchRuneMarketFromApi` return `null` for 404 responses

## Testing
- `pnpm test`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_685ee8ba4b4c83279f0fe3905f920332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing data by ensuring that "not found" responses are handled gracefully without triggering errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->