### PR TITLE
fix: use updated Liquidium API domain

### DIFF
--- a/src/lib/liquidiumSdk.ts
+++ b/src/lib/liquidiumSdk.ts
@@ -7,7 +7,7 @@ import { LiquidiumApi } from '@/sdk/liquidium';
  */
 export const createLiquidiumClient = (userJwt?: string): LiquidiumApi => {
   const baseUrlRaw =
-    process.env.LIQUIDIUM_API_URL || 'https://alpha.liquidium.wtf';
+    process.env.LIQUIDIUM_API_URL || 'https://alpha.liquidium.fi';
   // Remove any trailing slashes so generated SDK paths like "/api/v1/..." concatenate correctly
   const sanitizedBaseUrl = baseUrlRaw.replace(/\/+$/, '');
   const apiKey = process.env.LIQUIDIUM_API_KEY;


### PR DESCRIPTION
## Summary
- update default Liquidium API URL in `createLiquidiumClient`

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_685ee8ba4b4c83279f0fe3905f920332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default fallback URL for the Liquidium API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->