### PR TITLE
Fix formatNumberString zero handling

### DIFF
--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -55,6 +55,10 @@ describe('formatNumberString', () => {
     expect(formatNumberString(undefined, 'none')).toBe('none');
   });
 
+  it('handles zero correctly', () => {
+    expect(formatNumberString('0')).toBe('0');
+  });
+
   it('formats decimal and negative numbers', () => {
     expect(formatNumberString('-1234.56')).toBe('-1,234.56');
   });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -12,7 +12,9 @@ export function formatNumberString(
   numStr: string | undefined | null,
   defaultDisplay = 'N/A',
 ): string {
-  if (!numStr) return defaultDisplay;
+  if (numStr === undefined || numStr === null || numStr === '') {
+    return defaultDisplay;
+  }
 
   try {
     // Remove any existing commas and validate the string contains only digits


### PR DESCRIPTION
## Summary
- handle empty string explicitly in `formatNumberString`
- add unit test for zero value

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_b_685ee8ba4b4c83279f0fe3905f920332