### PR TITLE
fix: use correct Liquidium API domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ ORDISCAN_API_KEY=
 RUNES_FLOOR_API_KEY=
 
 # Liquidium API (client-side access)
-NEXT_PUBLIC_LIQUIDIUM_API_URL=https://alpha.liquidium.fi
+NEXT_PUBLIC_LIQUIDIUM_API_URL=https://alpha.liquidium.wtf
 NEXT_PUBLIC_LIQUIDIUM_API_KEY=
 
 # Liquidium API (server-side access)


### PR DESCRIPTION
## Summary
- revert default Liquidium API domain to `alpha.liquidium.wtf`
- update `.env.example` to match

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*
- `pnpm build` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_b_685ee8ba4b4c83279f0fe3905f920332

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default API URL in the environment example file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->