### PR TITLE
Fix missing cached popular runes in borrow quotes

### DIFF
--- a/src/components/BorrowTab.tsx
+++ b/src/components/BorrowTab.tsx
@@ -65,6 +65,9 @@ export function BorrowTab({
   paymentPublicKey,
   signPsbt,
   signMessage,
+  cachedPopularRunes = [],
+  isPopularRunesLoading = false,
+  popularRunesError = null,
 }: BorrowTabProps) {
   const router = useRouter();
   const [collateralAsset, setCollateralAsset] = useState<Asset | null>(null);
@@ -123,6 +126,9 @@ export function BorrowTab({
     collateralAmount,
     address,
     collateralRuneInfo: collateralRuneInfo ?? null,
+    cachedPopularRunes,
+    isPopularRunesLoading,
+    popularRunesError,
   });
 
   const {


### PR DESCRIPTION
## Summary
- pass cached popular runes into `useBorrowQuotes`
- use cached popular runes in hook when available

## Testing
- `pnpm lint`
- `pnpm test --runTestsByPath src/lib/apiUtils.test.ts`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_685f08c3867483279baa8d9c4cb2af80