### PR TITLE
Fix asset import path in PriceChart

### DIFF
--- a/src/components/PriceChart.tsx
+++ b/src/components/PriceChart.tsx
@@ -1,9 +1,5 @@
 import Image from 'next/image';
 import React, { useEffect, useState } from 'react';
-import usePriceChart from '@/hooks/usePriceChart';
-import styles from './AppInterface.module.css';
-import PriceTooltip from './PriceTooltip';
-import TimeframeSelector from './TimeframeSelector';
 import {
   CartesianGrid,
   Line,
@@ -13,7 +9,12 @@ import {
   XAxis,
   YAxis,
 } from 'recharts';
-import hourglassIcon from '/public/icons/windows_hourglass.png';
+import usePriceChart from '@/hooks/usePriceChart';
+import styles from './AppInterface.module.css';
+import PriceTooltip from './PriceTooltip';
+import TimeframeSelector from './TimeframeSelector';
+// Path to hourglass icon used while BTC price is loading
+const HOURGLASS_SRC = '/icons/windows_hourglass.png';
 
 interface PriceChartProps {
   assetName: string;
@@ -67,7 +68,7 @@ const PriceChart: React.FC<PriceChartProps> = ({
         }}
       >
         <Image
-          src={hourglassIcon.src || '/icons/windows_hourglass.png'}
+          src={HOURGLASS_SRC}
           alt="Loading..."
           width={48}
           height={48}


### PR DESCRIPTION
## Summary
- fix broken image import for loading spinner in `PriceChart`

## Testing
- `pnpm type-check`
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_685f08c5d8488327a15836f03d711bd3