### PR TITLE
Fix missing dependencies in hooks

### DIFF
--- a/src/hooks/useBorrowQuotes.test.ts
+++ b/src/hooks/useBorrowQuotes.test.ts
@@ -2,12 +2,15 @@ import { JSDOM } from 'jsdom';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
-import type { RuneData } from '@/lib/runesData';
-import type {
-  BorrowRangeResponse,
-  LiquidiumBorrowQuoteOffer,
-  LiquidiumBorrowQuoteResponse,
+import {
+  type BorrowRangeResponse,
+  type LiquidiumBorrowQuoteOffer,
+  type LiquidiumBorrowQuoteResponse,
+  fetchBorrowQuotesFromApi,
+  fetchBorrowRangesFromApi,
+  fetchPopularFromApi,
 } from '@/lib/apiClient';
+import type { RuneData } from '@/lib/runesData';
 
 // Mock the API client functions
 jest.mock('@/lib/apiClient', () => ({
@@ -29,11 +32,6 @@ jest.mock('@/utils/typeGuards', () => ({
 }));
 
 // Import the mocked functions for type safety
-import {
-  fetchBorrowQuotesFromApi,
-  fetchBorrowRangesFromApi,
-  fetchPopularFromApi,
-} from '@/lib/apiClient';
 import type { Asset } from '@/types/common';
 import useBorrowQuotes from './useBorrowQuotes';
 

--- a/src/hooks/useSwapQuote.ts
+++ b/src/hooks/useSwapQuote.ts
@@ -220,6 +220,7 @@ export function useSwapQuote({
     setQuote,
     setExchangeRate,
     setOutputAmount,
+    setQuoteTimestamp,
   ]);
 
   useEffect(() => {
@@ -311,6 +312,9 @@ export function useSwapQuote({
     quote,
     outputAmount,
     exchangeRate,
+    setQuote,
+    setOutputAmount,
+    setExchangeRate,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useSwapRunes.ts
+++ b/src/hooks/useSwapRunes.ts
@@ -49,7 +49,7 @@ export function useSwapRunes({
         return exists ? prev : [preSelectedAsset, ...prev];
       });
     }
-  }, [preSelectedAsset]);
+  }, [preSelectedAsset, setAssetIn, setAssetOut, hasLoadedPreselectedRune]);
 
   useEffect(() => {
     const fetchPopular = async () => {
@@ -194,7 +194,13 @@ export function useSwapRunes({
       }
     };
     fetchPopular();
-  }, [cachedPopularRunes, preSelectedRune, preSelectedAsset, assetOut]);
+  }, [
+    cachedPopularRunes,
+    preSelectedRune,
+    preSelectedAsset,
+    assetOut,
+    setAssetOut,
+  ]);
 
   useEffect(() => {
     const findAndSelectRune = async () => {
@@ -275,7 +281,14 @@ export function useSwapRunes({
     };
 
     findAndSelectRune();
-  }, [preSelectedRune, popularRunes, hasLoadedPreselectedRune]);
+  }, [
+    preSelectedRune,
+    popularRunes,
+    hasLoadedPreselectedRune,
+    setAssetIn,
+    setAssetOut,
+    assetOut,
+  ]);
 
   return {
     popularRunes,


### PR DESCRIPTION
## Summary
- clean up import order for useBorrowQuotes tests
- address React hook dependency warnings in useSwapQuote
- include missing refs in useSwapRunes

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_685f08c5d8488327a15836f03d711bd3