### PR TITLE
Fix isStale flag in cached popular runes API

### DIFF
--- a/src/app/api/cached-popular-runes/route.test.ts
+++ b/src/app/api/cached-popular-runes/route.test.ts
@@ -115,7 +115,7 @@ describe('/api/cached-popular-runes', () => {
         success: true,
         data: {
           data: mockCachedData,
-          isStale: true, // isExpired maps to isStale in response
+          isStale: false,
           cacheAge: new Date(lastRefreshTime).toISOString(),
         },
       });
@@ -196,7 +196,7 @@ describe('/api/cached-popular-runes', () => {
       const data = await response.json();
 
       expect(data.success).toBe(true);
-      expect(data.data.isStale).toBe(true);
+      expect(data.data.isStale).toBe(false);
       expect(data.data.error).toBe('Failed to fetch fresh data');
 
       expect(mockCachePopularRunes).not.toHaveBeenCalled();
@@ -219,7 +219,7 @@ describe('/api/cached-popular-runes', () => {
       const data = await response.json();
 
       expect(data.success).toBe(true);
-      expect(data.data.isStale).toBe(true);
+      expect(data.data.isStale).toBe(false);
       expect(data.data.error).toBe('Failed to fetch fresh data');
 
       expect(mockCachePopularRunes).not.toHaveBeenCalled();
@@ -263,7 +263,7 @@ describe('/api/cached-popular-runes', () => {
 
       expect(data.success).toBe(true);
       expect(data.data.data).toEqual(fallbackData);
-      expect(data.data.isStale).toBe(true);
+      expect(data.data.isStale).toBe(false);
       expect(data.data.error).toBe('Failed to fetch fresh data');
     });
   });
@@ -389,7 +389,7 @@ describe('/api/cached-popular-runes', () => {
       expect(response.status).toBe(200);
       const data = await response.json();
 
-      expect(data.data.isStale).toBe(true); // isExpired should map to isStale: true
+      expect(data.data.isStale).toBe(false);
     });
 
     it('should handle null lastRefreshAttempt', async () => {

--- a/src/app/api/cached-popular-runes/route.ts
+++ b/src/app/api/cached-popular-runes/route.ts
@@ -20,13 +20,8 @@ import { getSatsTerminalClient } from '@/lib/serverUtils';
 export async function GET() {
   try {
     // Get cached data with detailed metadata
-    const {
-      cachedData,
-      isExpired,
-      shouldAttemptRefresh,
-      isStale,
-      lastRefreshAttempt,
-    } = await getCachedPopularRunesWithMetadata();
+    const { cachedData, shouldAttemptRefresh, isStale, lastRefreshAttempt } =
+      await getCachedPopularRunesWithMetadata();
 
     // CRITICAL: We ALWAYS return cached data immediately when available
     // Even if it's expired, we use the stale-while-revalidate pattern
@@ -47,7 +42,7 @@ export async function GET() {
       // Return the cached data with a flag indicating if it's stale
       return createSuccessResponse({
         data: cachedData,
-        isStale: isExpired,
+        isStale,
         cacheAge: lastRefreshAttempt
           ? new Date(lastRefreshAttempt).toISOString()
           : null,


### PR DESCRIPTION
## Summary
- return the real `isStale` metadata in `/api/cached-popular-runes`
- update tests to reflect the corrected flag

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_685f24da957c8327ba4ad69e2ba0973d