### PR TITLE
Refactor fee fallback constant

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -49,6 +49,14 @@ export interface BitcoinFeeRates {
   minimumFee: number;
 }
 
+export const DEFAULT_FEE_RATES: BitcoinFeeRates = {
+  fastestFee: 25,
+  halfHourFee: 20,
+  hourFee: 15,
+  economyFee: 10,
+  minimumFee: 5,
+};
+
 export const fetchRecommendedFeeRates = async (): Promise<BitcoinFeeRates> => {
   try {
     const response = await fetch(
@@ -59,25 +67,13 @@ export const fetchRecommendedFeeRates = async (): Promise<BitcoinFeeRates> => {
       console.warn(
         `Failed to fetch fee rates: ${response.status} ${response.statusText}`,
       );
-      return {
-        fastestFee: 25,
-        halfHourFee: 20,
-        hourFee: 15,
-        economyFee: 10,
-        minimumFee: 5,
-      };
+      return DEFAULT_FEE_RATES;
     }
 
     const data = await response.json();
     return data as BitcoinFeeRates;
   } catch (error) {
     console.warn('Error fetching recommended fee rates:', error);
-    return {
-      fastestFee: 25,
-      halfHourFee: 20,
-      hourFee: 15,
-      economyFee: 10,
-      minimumFee: 5,
-    };
+    return DEFAULT_FEE_RATES;
   }
 };


### PR DESCRIPTION
## Summary
- centralize default fallback rates in `DEFAULT_FEE_RATES`
- reuse constant in `fetchRecommendedFeeRates`

## Testing
- `pnpm lint`
- `pnpm jest src/utils/formatters.test.ts`

------
https://chatgpt.com/codex/tasks/task_b_685f267c38c48327874790ca71ac3b72