### PR TITLE
Refactor useBtcPrice hook

### DIFF
--- a/src/hooks/useBtcPrice.ts
+++ b/src/hooks/useBtcPrice.ts
@@ -1,23 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-
-const COINGECKO_BTC_PRICE_URL =
-  'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd';
-
-const getBtcPrice = async (): Promise<number> => {
-  const response = await fetch(COINGECKO_BTC_PRICE_URL);
-  if (!response.ok) {
-    if (response.status === 429) {
-      throw new Error('Rate limit exceeded for CoinGecko API');
-    }
-    throw new Error(
-      `Failed to fetch BTC price from CoinGecko: ${response.status}`,
-    );
-  }
-  const data = await response.json();
-  if (!data.bitcoin || !data.bitcoin.usd)
-    throw new Error('Invalid response format from CoinGecko');
-  return data.bitcoin.usd;
-};
+import { getBtcPrice } from '@/lib/api';
 
 export function useBtcPrice() {
   const { data, isLoading, error } = useQuery<number, Error>({


### PR DESCRIPTION
## Summary
- reuse shared `getBtcPrice` API util inside `useBtcPrice` hook

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm test` *(fails: exceeded execution time)*

------
https://chatgpt.com/codex/tasks/task_b_685f267c38c48327874790ca71ac3b72