### PR TITLE
Refactor PSBT handling with typed responses

### DIFF
--- a/src/lib/api/satsTerminal.ts
+++ b/src/lib/api/satsTerminal.ts
@@ -3,7 +3,11 @@ import {
   type GetPSBTParams,
   type QuoteResponse,
 } from 'satsterminal-sdk';
-import type { Rune } from '@/types/satsTerminal';
+import type {
+  PsbtConfirmationResult,
+  PsbtCreationResult,
+  Rune,
+} from '@/types/satsTerminal';
 import { handleApiResponse } from './utils';
 
 export const fetchRunesFromApi = async (query: string): Promise<Rune[]> => {
@@ -56,7 +60,7 @@ export const fetchQuoteFromApi = async (
 
 export const getPsbtFromApi = async (
   params: GetPSBTParams,
-): Promise<Record<string, unknown>> => {
+): Promise<PsbtCreationResult> => {
   const response = await fetch('/api/sats-terminal/psbt/create', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -75,12 +79,12 @@ export const getPsbtFromApi = async (
         `Failed to create PSBT: ${response.statusText}`,
     );
   }
-  return data as Record<string, unknown>;
+  return data as PsbtCreationResult;
 };
 
 export const confirmPsbtViaApi = async (
   params: ConfirmPSBTParams,
-): Promise<Record<string, unknown>> => {
+): Promise<PsbtConfirmationResult> => {
   const response = await fetch('/api/sats-terminal/psbt/confirm', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -99,5 +103,5 @@ export const confirmPsbtViaApi = async (
         `Failed to confirm PSBT: ${response.statusText}`,
     );
   }
-  return data as Record<string, unknown>;
+  return data as PsbtConfirmationResult;
 };

--- a/src/types/satsTerminal.ts
+++ b/src/types/satsTerminal.ts
@@ -56,3 +56,23 @@ export interface RuneOrder {
   name?: string | undefined;
   amount?: string | undefined;
 }
+
+// API response when creating a PSBT
+export interface PsbtCreationResult {
+  psbtBase64?: string;
+  psbt?: string;
+  swapId?: string;
+  rbfProtected?: {
+    base64?: string;
+  };
+  [key: string]: unknown;
+}
+
+// API response when confirming a PSBT
+export interface PsbtConfirmationResult {
+  txid?: string;
+  rbfProtection?: {
+    fundsPreparationTxId?: string;
+  };
+  [key: string]: unknown;
+}

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -36,15 +36,3 @@ export function formatNumberString(
     return defaultDisplay;
   }
 }
-
-export function formatNumber(value: number): string {
-  if (value === 0) return '0';
-  const str = value.toString();
-  const parts = str.split('.');
-  const intPart = safeArrayFirst(parts);
-  if (!intPart) return '0';
-
-  const withCommas = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-  const decPart = safeArrayAccess(parts, 1);
-  return decPart ? `${withCommas}.${decPart}` : withCommas;
-}


### PR DESCRIPTION
## Summary
- add `PsbtCreationResult` and `PsbtConfirmationResult` types
- return typed responses from SatsTerminal API helpers
- use typed PSBT data inside `useSwapExecution`
- remove unused `formatNumber` helper

## Testing
- `pnpm test`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_b_685f268b43988327af1a8df7372cace3