### PR TITLE
refactor: centralize rune amount helpers

### DIFF
--- a/src/components/borrow/BorrowTab.tsx
+++ b/src/components/borrow/BorrowTab.tsx
@@ -15,7 +15,7 @@ import { useRuneMarketData } from '@/hooks/useRuneMarketData';
 import { QUERY_KEYS, fetchRuneBalancesFromApi } from '@/lib/api';
 import { Asset } from '@/types/common';
 import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
-import { percentageOfRawAmount } from '@/utils/amountFormatting';
+import { percentageOfRawAmount } from '@/utils/runeFormatting';
 import { formatUsd } from '@/utils/formatters';
 import BorrowQuotesList from '@/components/borrow/BorrowQuotesList';
 import BorrowSuccessMessage from '@/components/borrow/BorrowSuccessMessage';

--- a/src/components/swap/SwapTab.tsx
+++ b/src/components/swap/SwapTab.tsx
@@ -18,9 +18,9 @@ import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
 import {
   formatAmountWithPrecision,
   percentageOfRawAmount,
-} from '@/utils/amountFormatting';
+  calculateActualBalance,
+} from '@/utils/runeFormatting';
 import { formatNumberWithLocale } from '@/utils/formatters';
-import { calculateActualBalance } from '@/utils/runeFormatting';
 import { Loading } from '@/components/loading';
 import FeeSelector from '@/components/ui/FeeSelector';
 import styles from '@/components/swap/SwapTab.module.css';

--- a/src/hooks/useBorrowProcess.ts
+++ b/src/hooks/useBorrowProcess.ts
@@ -1,5 +1,5 @@
 //
-import { convertToRawAmount } from '@/utils/amountFormatting';
+import { convertToRawAmount } from '@/utils/runeFormatting';
 import { useState } from 'react';
 import {
   LiquidiumPrepareBorrowResponse,

--- a/src/hooks/useBorrowQuotes.ts
+++ b/src/hooks/useBorrowQuotes.ts
@@ -1,5 +1,5 @@
 import Big from 'big.js';
-import { convertToRawAmount } from '@/utils/amountFormatting';
+import { convertToRawAmount } from '@/utils/runeFormatting';
 import { useEffect, useState } from 'react';
 import {
   LiquidiumBorrowQuoteOffer,


### PR DESCRIPTION
## Summary
- centralize Big.js amount helpers for runes
- update modules to use shared formatting utilities

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `pnpm ai-check` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ba7d39e0832393fee5dbbf571441