### PR TITLE
docs(readme): add release badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # RunesSwap.app
 
+[![Release](https://img.shields.io/github/v/release/ropl-btc/RunesSwap.app)](https://github.com/ropl-btc/RunesSwap.app/releases)
+
 A Uniswap‑style swap interface for Bitcoin Runes, built with Next.js, TypeScript, and the SatsTerminal SDK, styled in a classic Windows 98 UI theme.
 
 ## Features


### PR DESCRIPTION
Add a release badge linking to GitHub Releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a GitHub Releases badge to the README, linking directly to the project’s releases page for quick access to release notes and downloads.
  * Improves visibility of version history for users.
  * No changes to application behavior or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->