### PR TITLE
chore(release): 0.2.3 – add Changelog page and footer link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2025-08-24
+
+### Added
+
+- Changelog page at `/changelog` that renders CHANGELOG content without the preamble and link reference block (shows only versions, dates, and changes).
+- Footer "Changelog" button next to "Docs" for quick access.
+
 ## [0.2.2] - 2025-08-23
 
 ### Added
@@ -130,3 +137,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ropl-btc/RunesSwap.app/releases/tag/v0.1.0
+[0.2.3]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.2...v0.2.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runesswap.app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --runInBand",

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import styles from '@/app/page.module.css';
+
+function getCleanChangelog(raw: string): string {
+  const lines = raw.split(/\r?\n/);
+
+  // Find first version heading (e.g., "## [0.2.1] - 2025-08-23" or any H2)
+  let startIdx = lines.findIndex((l) => l.trim().startsWith('## '));
+  if (startIdx === -1) startIdx = 0;
+
+  // Slice from first H2 to end
+  const sliced = lines.slice(startIdx);
+
+  // Filter out reference-style link definitions at the bottom like: [0.2.1]: https://...
+  const filtered = sliced.filter(
+    (l) => !/^\[[^\]]+\]:\s*https?:\/\//.test(l.trim()),
+  );
+
+  return filtered.join('\n').trim();
+}
+
+export default function ChangelogPage() {
+  const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
+  let fileContents = '';
+  try {
+    fileContents = fs.readFileSync(changelogPath, 'utf-8');
+  } catch (err) {
+    console.error('Error reading CHANGELOG.md:', err);
+  }
+
+  const content = getCleanChangelog(fileContents);
+
+  return (
+    <div className={styles.container}>
+      <h1 className="heading">Changelog</h1>
+      <div className={styles.docsContent}>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+      </div>
+      <div className={styles.backToHome}>
+        <Link href="/">Back to Home</Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/FooterComponent.tsx
+++ b/src/components/layout/FooterComponent.tsx
@@ -35,6 +35,11 @@ export function FooterComponent({
             Docs
           </a>
         </Link>
+        <Link href="/changelog" legacyBehavior passHref>
+          <a className={buttonStyles.root} title="Changelog">
+            Changelog
+          </a>
+        </Link>
         <Link href="/legal" legacyBehavior passHref>
           <a className={buttonStyles.root} title="Legal">
             Legal


### PR DESCRIPTION
- Added a new /changelog page that renders CHANGELOG content without the preamble and link reference block (versions, dates, changes only).
- Added a "Changelog" button in the footer next to "Docs".

This PR bumps the version to 0.2.3 and updates the CHANGELOG accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Changelog page at /changelog showing versions, dates, and changes.
  - Added a “Changelog” button in the footer for quick access.

- Documentation
  - Updated CHANGELOG with a new 0.2.3 entry.

- Chores
  - Bumped app version to 0.2.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->