### PR TITLE
feat: consolidate rune data fetching hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Consolidated rune data fetching hooks with new `useRuneDataQuery` wrapper.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/hooks/__tests__/useRuneDataHooks.test.ts
+++ b/src/hooks/__tests__/useRuneDataHooks.test.ts
@@ -1,0 +1,41 @@
+import { renderHook } from '@testing-library/react';
+import { useRuneInfo } from '@/hooks/useRuneInfo';
+import { useRuneMarketData } from '@/hooks/useRuneMarketData';
+
+jest.mock('@/hooks/useRuneDataQuery', () => ({ useRuneDataQuery: jest.fn() }));
+jest.mock('@/lib/api', () => ({
+  fetchRuneInfoFromApi: jest.fn(),
+  fetchRuneMarketFromApi: jest.fn(),
+}));
+
+const { useRuneDataQuery } = jest.requireMock('@/hooks/useRuneDataQuery');
+const { fetchRuneInfoFromApi, fetchRuneMarketFromApi } =
+  jest.requireMock('@/lib/api');
+
+describe('rune data hooks', () => {
+  beforeEach(() => {
+    (useRuneDataQuery as jest.Mock).mockReturnValue({ data: 'mock' });
+  });
+
+  it('useRuneInfo delegates to useRuneDataQuery', () => {
+    const { result } = renderHook(() => useRuneInfo('TEST'));
+    expect(useRuneDataQuery).toHaveBeenCalledWith(
+      'runeInfo',
+      'TEST',
+      fetchRuneInfoFromApi,
+      { staleTime: Infinity, retry: 2 },
+    );
+    expect(result.current.data).toBe('mock');
+  });
+
+  it('useRuneMarketData delegates to useRuneDataQuery', () => {
+    const { result } = renderHook(() => useRuneMarketData('TEST'));
+    expect(useRuneDataQuery).toHaveBeenCalledWith(
+      'runeMarket',
+      'TEST',
+      fetchRuneMarketFromApi,
+      { staleTime: 60000, retry: 2 },
+    );
+    expect(result.current.data).toBe('mock');
+  });
+});

--- a/src/hooks/__tests__/useRuneDataQuery.test.ts
+++ b/src/hooks/__tests__/useRuneDataQuery.test.ts
@@ -1,0 +1,26 @@
+import { renderHook } from '@testing-library/react';
+import { useRuneDataQuery } from '@/hooks/useRuneDataQuery';
+
+jest.mock('@/hooks/useApiQuery', () => ({ useApiQuery: jest.fn() }));
+
+const { useApiQuery } = jest.requireMock('@/hooks/useApiQuery');
+
+describe('useRuneDataQuery', () => {
+  it('delegates to useApiQuery with provided options', () => {
+    const fetcher = jest.fn();
+    (useApiQuery as jest.Mock).mockReturnValue({ data: 'mock' });
+
+    const { result } = renderHook(() =>
+      useRuneDataQuery('testKey', 'TEST', fetcher, {
+        staleTime: 5,
+        retry: 1,
+      }),
+    );
+
+    expect(useApiQuery).toHaveBeenCalledWith('testKey', 'TEST', fetcher, 5, {
+      enabled: true,
+      retry: 1,
+    });
+    expect(result.current.data).toBe('mock');
+  });
+});

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -8,11 +8,14 @@ export function useApiQuery<TData>(
   parameter: string | null | undefined,
   queryFn: (param: string) => Promise<TData | null>,
   staleTime = Infinity,
+  options: { enabled?: boolean; retry?: number } = {},
 ) {
+  const { enabled = !!parameter, retry } = options;
   return useQuery({
     queryKey: [queryKey, parameter?.toUpperCase() || ''],
     queryFn: () => (parameter ? queryFn(parameter) : Promise.resolve(null)),
-    enabled: !!parameter,
+    enabled,
     staleTime,
+    ...(retry !== undefined ? { retry } : {}),
   });
 }

--- a/src/hooks/useRuneDataQuery.ts
+++ b/src/hooks/useRuneDataQuery.ts
@@ -1,0 +1,22 @@
+import { useApiQuery } from '@/hooks/useApiQuery';
+
+interface UseRuneDataOptions {
+  enabled?: boolean;
+  staleTime?: number;
+  retry?: number;
+}
+
+export function useRuneDataQuery<T>(
+  queryKey: string,
+  runeName: string | null | undefined,
+  fetcher: (rune: string) => Promise<T | null>,
+  options: UseRuneDataOptions = {},
+) {
+  const { enabled = !!runeName, staleTime, retry } = options;
+  const config: { enabled: boolean; retry?: number } = { enabled };
+  if (retry !== undefined) {
+    config.retry = retry;
+  }
+
+  return useApiQuery(queryKey, runeName, fetcher, staleTime, config);
+}

--- a/src/hooks/useRuneInfo.ts
+++ b/src/hooks/useRuneInfo.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { fetchRuneInfoFromApi } from '@/lib/api';
+import { useRuneDataQuery } from '@/hooks/useRuneDataQuery';
 
 interface UseRuneInfoOptions {
   enabled?: boolean;
@@ -14,14 +14,9 @@ export function useRuneInfo(
   runeName: string | null | undefined,
   options: UseRuneInfoOptions = {},
 ) {
-  const { enabled = !!runeName, staleTime = Infinity, retry = 2 } = options;
-
-  return useQuery({
-    queryKey: ['runeInfo', runeName?.toUpperCase() || ''],
-    queryFn: () =>
-      runeName ? fetchRuneInfoFromApi(runeName) : Promise.resolve(null),
-    enabled: enabled && !!runeName,
-    staleTime,
-    retry,
+  return useRuneDataQuery('runeInfo', runeName, fetchRuneInfoFromApi, {
+    staleTime: Infinity,
+    retry: 2,
+    ...options,
   });
 }

--- a/src/hooks/useRuneMarketData.ts
+++ b/src/hooks/useRuneMarketData.ts
@@ -1,5 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
 import { fetchRuneMarketFromApi } from '@/lib/api';
+import { useRuneDataQuery } from '@/hooks/useRuneDataQuery';
 
 interface UseRuneMarketDataOptions {
   enabled?: boolean;
@@ -14,14 +14,9 @@ export function useRuneMarketData(
   runeName: string | null | undefined,
   options: UseRuneMarketDataOptions = {},
 ) {
-  const { enabled = !!runeName, staleTime = 60000, retry = 2 } = options;
-
-  return useQuery({
-    queryKey: ['runeMarket', runeName?.toUpperCase() || ''],
-    queryFn: () =>
-      runeName ? fetchRuneMarketFromApi(runeName) : Promise.resolve(null),
-    enabled: enabled && !!runeName,
-    staleTime,
-    retry,
+  return useRuneDataQuery('runeMarket', runeName, fetchRuneMarketFromApi, {
+    staleTime: 60000,
+    retry: 2,
+    ...options,
   });
 }


### PR DESCRIPTION
## Summary
- add shared `useRuneDataQuery` wrapper around `useApiQuery`
- refactor rune info and market data hooks to use the new wrapper
- add tests for rune data query hooks

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa675685d083238db2901a4db84713