### PR TITLE
feat(api): add fetchRuneEndpoint helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Helper `fetchRuneEndpoint` for Ordiscan rune endpoints with accompanying tests.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/lib/api/__tests__/consolidated.test.ts
+++ b/src/lib/api/__tests__/consolidated.test.ts
@@ -8,6 +8,7 @@ import {
   fetchPortfolioDataFromApi,
   fetchRuneActivityFromApi,
   fetchRuneBalancesFromApi,
+  fetchRuneEndpoint,
   fetchRuneInfoFromApi,
   fetchRuneMarketFromApi,
   fetchRunePriceHistoryFromApi,
@@ -71,6 +72,25 @@ describe('API Client Functions', () => {
     [testData.popularRune()],
     true,
   );
+
+  describe('fetchRuneEndpoint', () => {
+    it('normalizes names and uses apiGet for GET', async () => {
+      (apiGet as jest.Mock).mockResolvedValue(testData.runeData);
+      const result = await fetchRuneEndpoint('/api/test', 'GET', 'RUNE•TEST');
+      expect(apiGet).toHaveBeenCalledWith('/api/test', { name: 'RUNETEST' });
+      expect(result).toEqual(testData.runeData);
+    });
+
+    it('uses apiPost for POST and returns null on errors', async () => {
+      (apiPost as jest.Mock).mockResolvedValue(testData.runeData);
+      const result = await fetchRuneEndpoint('/api/test', 'POST', 'RUNE1');
+      expect(apiPost).toHaveBeenCalledWith('/api/test', { name: 'RUNE1' });
+      expect(result).toEqual(testData.runeData);
+
+      (apiPost as jest.Mock).mockRejectedValue(new Error('fail'));
+      expect(await fetchRuneEndpoint('/api/test', 'POST', 'RUNE1')).toBeNull();
+    });
+  });
 
   describe('fetchRuneInfoFromApi', () => {
     it('normalizes rune names and handles success/error cases', async () => {

--- a/src/lib/api/ordiscan.ts
+++ b/src/lib/api/ordiscan.ts
@@ -8,6 +8,20 @@ import { normalizeRuneName } from '@/utils/runeUtils';
 import { type RuneData } from '@/lib/runesData';
 import { apiGet, apiPost } from '@/lib/api/createApiClient';
 
+export const fetchRuneEndpoint = async <T>(
+  endpoint: string,
+  method: 'GET' | 'POST',
+  name: string,
+): Promise<T | null> => {
+  try {
+    const normalizedName = normalizeRuneName(name);
+    const requester = method === 'POST' ? apiPost : apiGet;
+    return await requester<T>(endpoint, { name: normalizedName });
+  } catch {
+    return null;
+  }
+};
+
 export const fetchBtcBalanceFromApi = async (
   address: string,
 ): Promise<number> => {
@@ -26,43 +40,22 @@ export const fetchRuneBalancesFromApi = async (
 
 export const fetchRuneInfoFromApi = async (
   name: string,
-): Promise<RuneData | null> => {
-  try {
-    const normalizedName = normalizeRuneName(name);
-    return await apiGet<RuneData>('/api/ordiscan/rune-info', {
-      name: normalizedName,
-    });
-  } catch {
-    // Return null for 404s or other failures
-    return null;
-  }
-};
+): Promise<RuneData | null> =>
+  fetchRuneEndpoint<RuneData>('/api/ordiscan/rune-info', 'GET', name);
 
 export const updateRuneDataViaApi = async (
   name: string,
-): Promise<RuneData | null> => {
-  try {
-    const normalizedName = normalizeRuneName(name);
-    return await apiPost<RuneData>('/api/ordiscan/rune-update', {
-      name: normalizedName,
-    });
-  } catch {
-    return null;
-  }
-};
+): Promise<RuneData | null> =>
+  fetchRuneEndpoint<RuneData>('/api/ordiscan/rune-update', 'POST', name);
 
 export const fetchRuneMarketFromApi = async (
   name: string,
-): Promise<OrdiscanRuneMarketInfo | null> => {
-  try {
-    const normalizedName = normalizeRuneName(name);
-    return await apiGet<OrdiscanRuneMarketInfo>('/api/ordiscan/rune-market', {
-      name: normalizedName,
-    });
-  } catch {
-    return null;
-  }
-};
+): Promise<OrdiscanRuneMarketInfo | null> =>
+  fetchRuneEndpoint<OrdiscanRuneMarketInfo>(
+    '/api/ordiscan/rune-market',
+    'GET',
+    name,
+  );
 
 export const fetchListRunesFromApi = async (): Promise<OrdiscanRuneInfo[]> =>
   apiGet<OrdiscanRuneInfo[]>('/api/ordiscan/list-runes');


### PR DESCRIPTION
## Summary
- add fetchRuneEndpoint for reusable Ordiscan rune calls
- refactor rune info, update, and market fetches to use helper
- test coverage for new helper

## Testing
- `pnpm test`
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa676b84388323abb2575ce490f064