### PR TITLE
feat: centralize popular runes fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Centralized `usePopularRunes` hook and refactored hooks/components to consume it.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/components/borrow/BorrowTab.tsx
+++ b/src/components/borrow/BorrowTab.tsx
@@ -51,9 +51,6 @@ interface BorrowTabProps {
   btcPriceUsd: number | undefined;
   isBtcPriceLoading: boolean;
   btcPriceError: Error | null;
-  cachedPopularRunes?: Record<string, unknown>[] | undefined;
-  isPopularRunesLoading?: boolean | undefined;
-  popularRunesError?: Error | null | undefined;
 }
 
 export function BorrowTab({
@@ -64,9 +61,6 @@ export function BorrowTab({
   paymentPublicKey,
   signPsbt,
   signMessage,
-  cachedPopularRunes = [],
-  isPopularRunesLoading = false,
-  popularRunesError = null,
 }: BorrowTabProps) {
   const router = useRouter();
   const [collateralAsset, setCollateralAsset] = useState<Asset | null>(null);
@@ -114,9 +108,6 @@ export function BorrowTab({
     collateralAmount,
     address,
     collateralRuneInfo: collateralRuneInfo ?? null,
-    cachedPopularRunes,
-    isPopularRunesLoading,
-    popularRunesError,
   });
 
   const {
@@ -206,7 +197,7 @@ export function BorrowTab({
         }}
         availableAssets={popularRunes}
         isAssetsLoading={isPopularLoading}
-        assetsError={popularError}
+        assetsError={popularError?.message || null}
         disabled={isLoading}
         availableBalance={availableBalanceDisplay}
         usdValue={usdValue}

--- a/src/components/layout/AppInterface.tsx
+++ b/src/components/layout/AppInterface.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
 import React, { useEffect, useState } from 'react';
 import { useSharedLaserEyes } from '@/context/LaserEyesContext';
 import useBtcPrice from '@/hooks/useBtcPrice';
-import { QUERY_KEYS, fetchPopularFromApi } from '@/lib/api';
 import type { Asset } from '@/types/common';
 import { Loading } from '@/components/loading';
 import styles from '@/components/layout/AppInterface.module.css';
@@ -118,17 +116,6 @@ export function AppInterface({ activeTab }: AppInterfaceProps) {
   const { btcPriceUsd, isBtcPriceLoading, btcPriceError } = useBtcPrice();
 
   // Fetch popular runes once - it's now a simple static list
-  const {
-    data: popularRunes,
-    isLoading: isPopularRunesLoading,
-    error: popularRunesError,
-  } = useQuery<Record<string, unknown>[], Error>({
-    queryKey: [QUERY_KEYS.POPULAR_RUNES],
-    queryFn: () => fetchPopularFromApi(),
-    staleTime: Infinity, // Never refetch - it's a hardcoded list
-    gcTime: Infinity, // Keep forever
-  });
-
   const togglePriceChart = React.useCallback(
     (assetName?: string, shouldToggle: boolean = true) => {
       if (activeTab === 'swap') {
@@ -196,9 +183,6 @@ export function AppInterface({ activeTab }: AppInterfaceProps) {
             btcPriceUsd={btcPriceUsd}
             isBtcPriceLoading={isBtcPriceLoading}
             btcPriceError={btcPriceError}
-            cachedPopularRunes={popularRunes || []}
-            isPopularRunesLoading={isPopularRunesLoading}
-            popularRunesError={popularRunesError}
             onShowPriceChart={togglePriceChart}
             showPriceChart={showSwapTabPriceChart}
             preSelectedRune={preSelectedRune}
@@ -219,18 +203,12 @@ export function AppInterface({ activeTab }: AppInterfaceProps) {
             btcPriceUsd={btcPriceUsd}
             isBtcPriceLoading={isBtcPriceLoading}
             btcPriceError={btcPriceError}
-            cachedPopularRunes={popularRunes || []} // Pass popular runes
-            isPopularRunesLoading={isPopularRunesLoading}
-            popularRunesError={popularRunesError}
           />
         );
       // --- End Borrow Tab Case ---
       case 'runesInfo':
         return (
           <RunesInfoTab
-            cachedPopularRunes={popularRunes || []}
-            isPopularRunesLoading={isPopularRunesLoading}
-            popularRunesError={popularRunesError}
             onShowPriceChart={togglePriceChart}
             showPriceChart={showRunesInfoTabPriceChart}
           />
@@ -252,9 +230,6 @@ export function AppInterface({ activeTab }: AppInterfaceProps) {
             btcPriceUsd={btcPriceUsd}
             isBtcPriceLoading={isBtcPriceLoading}
             btcPriceError={btcPriceError}
-            cachedPopularRunes={popularRunes || []}
-            isPopularRunesLoading={isPopularRunesLoading}
-            popularRunesError={popularRunesError}
             onShowPriceChart={togglePriceChart}
             showPriceChart={showSwapTabPriceChart}
             preSelectedRune={preSelectedRune}

--- a/src/components/runes/RuneSearchBar.tsx
+++ b/src/components/runes/RuneSearchBar.tsx
@@ -10,17 +10,11 @@ import styles from '@/components/runes/RunesInfoTab.module.css';
 interface RuneSearchBarProps {
   onRuneSelect: (rune: Rune) => void;
   selectedRuneName?: string | null;
-  cachedPopularRunes?: Record<string, unknown>[];
-  isPopularRunesLoading?: boolean;
-  popularRunesError?: Error | null;
 }
 
 const RuneSearchBar: React.FC<RuneSearchBarProps> = ({
   onRuneSelect,
   selectedRuneName,
-  cachedPopularRunes = [],
-  isPopularRunesLoading = false,
-  popularRunesError = null,
 }) => {
   const {
     searchQuery,
@@ -31,11 +25,7 @@ const RuneSearchBar: React.FC<RuneSearchBarProps> = ({
     availableRunes,
     isLoadingRunes,
     currentRunesError,
-  } = useRunesSearch({
-    cachedPopularRunes,
-    isPopularRunesLoading,
-    popularRunesError,
-  });
+  } = useRunesSearch();
 
   return (
     <div className={styles.searchAndResultsContainer}>

--- a/src/components/runes/RunesInfoTab.tsx
+++ b/src/components/runes/RunesInfoTab.tsx
@@ -11,17 +11,11 @@ import RuneSearchBar from '@/components/runes/RuneSearchBar';
 import styles from '@/components/runes/RunesInfoTab.module.css';
 
 interface RunesInfoTabProps {
-  cachedPopularRunes?: Record<string, unknown>[];
-  isPopularRunesLoading?: boolean;
-  popularRunesError?: Error | null;
   onShowPriceChart?: (assetName?: string, shouldToggle?: boolean) => void;
   showPriceChart?: boolean;
 }
 
 export function RunesInfoTab({
-  cachedPopularRunes = [],
-  isPopularRunesLoading = false,
-  popularRunesError = null,
   onShowPriceChart,
   showPriceChart = false,
 }: RunesInfoTabProps) {
@@ -101,9 +95,6 @@ export function RunesInfoTab({
       <RuneSearchBar
         onRuneSelect={handleRuneSelect}
         selectedRuneName={selectedRuneForInfo?.name || null}
-        cachedPopularRunes={cachedPopularRunes}
-        isPopularRunesLoading={isPopularRunesLoading}
-        popularRunesError={popularRunesError}
       />
       <RuneDetails
         selectedRune={selectedRuneForInfo}

--- a/src/components/swap/SwapTab.tsx
+++ b/src/components/swap/SwapTab.tsx
@@ -47,10 +47,6 @@ interface SwapTabProps {
   btcPriceUsd: number | undefined;
   isBtcPriceLoading: boolean;
   btcPriceError: Error | null;
-  // New props for cached popular runes
-  cachedPopularRunes?: Record<string, unknown>[];
-  isPopularRunesLoading?: boolean;
-  popularRunesError?: Error | null;
   // New props for price chart
   onShowPriceChart?: (assetName?: string, shouldToggle?: boolean) => void;
   showPriceChart?: boolean;
@@ -68,9 +64,6 @@ export function SwapTab({
   btcPriceUsd,
   isBtcPriceLoading,
   btcPriceError,
-  cachedPopularRunes = [],
-  isPopularRunesLoading = false,
-  popularRunesError = null,
   onShowPriceChart,
   showPriceChart = false,
   preSelectedRune = null,
@@ -91,9 +84,6 @@ export function SwapTab({
     popularError,
     isPreselectedRuneLoading,
   } = useSwapRunes({
-    cachedPopularRunes,
-    isPopularRunesLoading,
-    popularRunesError,
     preSelectedRune,
     preSelectedAsset,
     assetOut,
@@ -103,7 +93,7 @@ export function SwapTab({
 
   const availableRunes = popularRunes;
   const isLoadingRunes = isPopularLoading;
-  const currentRunesError = popularError;
+  const currentRunesError = popularError?.message || null;
 
   // Add back loadingDots state for animation
   const [loadingDots, setLoadingDots] = useState('.');

--- a/src/hooks/usePopularRunes.ts
+++ b/src/hooks/usePopularRunes.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { QUERY_KEYS, fetchPopularFromApi } from '@/lib/api';
+
+export function usePopularRunes<T = Record<string, unknown>>(
+  mapper?: (data: Record<string, unknown>[]) => T[],
+) {
+  const { data, isLoading, error } = useQuery<Record<string, unknown>[], Error>(
+    {
+      queryKey: [QUERY_KEYS.POPULAR_RUNES],
+      queryFn: fetchPopularFromApi,
+      staleTime: Infinity,
+      gcTime: Infinity,
+    },
+  );
+
+  const mapped =
+    mapper && data ? mapper(data) : ((data ?? []) as unknown as T[]);
+
+  return {
+    popularRunes: mapped,
+    isLoading,
+    error: error ?? null,
+  };
+}
+
+export default usePopularRunes;

--- a/src/hooks/useSwapRunes.ts
+++ b/src/hooks/useSwapRunes.ts
@@ -1,14 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
-import { fetchPopularFromApi, fetchRunesFromApi } from '@/lib/api';
+import { useEffect, useState } from 'react';
+import { fetchRunesFromApi } from '@/lib/api';
 import { Asset, BTC_ASSET } from '@/types/common';
 import { mapPopularToAsset } from '@/utils/popularRunes';
 import { normalizeRuneName } from '@/utils/runeUtils';
 import { safeArrayFirst } from '@/utils/typeGuards';
+import usePopularRunes from '@/hooks/usePopularRunes';
 
 interface UseSwapRunesArgs {
-  cachedPopularRunes?: Record<string, unknown>[];
-  isPopularRunesLoading?: boolean;
-  popularRunesError?: Error | null;
   preSelectedRune?: string | null;
   preSelectedAsset?: Asset | null;
   assetOut: Asset | null;
@@ -17,27 +15,22 @@ interface UseSwapRunesArgs {
 }
 
 export function useSwapRunes({
-  cachedPopularRunes = [],
-  isPopularRunesLoading = false,
-  popularRunesError = null,
   preSelectedRune = null,
   preSelectedAsset = null,
   assetOut,
   setAssetIn,
   setAssetOut,
 }: UseSwapRunesArgs) {
+  const {
+    popularRunes: basePopularRunes,
+    isLoading: isPopularLoading,
+    error: popularError,
+  } = usePopularRunes<Asset>(mapPopularToAsset);
   const [popularRunes, setPopularRunes] = useState<Asset[]>([]);
-  const [isPopularLoading, setIsPopularLoading] = useState(
-    isPopularRunesLoading,
-  );
-  const [popularError, setPopularError] = useState<string | null>(
-    popularRunesError ? popularRunesError.message : null,
-  );
   const [isPreselectedRuneLoading, setIsPreselectedRuneLoading] =
     useState(!!preSelectedRune);
   const [hasLoadedPreselectedRune, setHasLoadedPreselectedRune] =
     useState(false);
-  const hasLoadedPopularRunes = useRef(false);
 
   useEffect(() => {
     if (preSelectedAsset && !hasLoadedPreselectedRune) {
@@ -45,60 +38,26 @@ export function useSwapRunes({
       setAssetOut(preSelectedAsset);
       setIsPreselectedRuneLoading(false);
       setHasLoadedPreselectedRune(true);
-      setPopularRunes((prev) => {
-        const exists = prev.some((r) => r.id === preSelectedAsset.id);
-        return exists ? prev : [preSelectedAsset, ...prev];
-      });
     }
   }, [preSelectedAsset, setAssetIn, setAssetOut, hasLoadedPreselectedRune]);
 
   useEffect(() => {
-    const fetchPopular = async () => {
-      if (hasLoadedPopularRunes.current) return;
-
-      // Try cached data first, then fetch if needed
-      const runesData =
-        cachedPopularRunes && cachedPopularRunes.length > 0
-          ? cachedPopularRunes
-          : await fetchPopularFromApi();
-
-      // Convert to Asset format - LIQUIDIUM•TOKEN is already first in our list
-      let mappedRunes: Asset[] = mapPopularToAsset(runesData);
-
-      // Add preselected asset if it's not in the list
-      if (preSelectedAsset) {
-        const exists = mappedRunes.some((r) => r.id === preSelectedAsset.id);
-        if (!exists) {
-          mappedRunes = [preSelectedAsset, ...mappedRunes];
-        }
-      }
-
-      setPopularRunes(mappedRunes);
-
-      // Set first rune as output if no preselection and no current output
-      if (!preSelectedRune && !assetOut && mappedRunes.length > 0) {
-        const firstRune = safeArrayFirst(mappedRunes);
-        if (firstRune) {
-          setAssetOut(firstRune);
-        }
-      }
-
-      setIsPopularLoading(false);
-      hasLoadedPopularRunes.current = true;
-    };
-
-    fetchPopular().catch((error) => {
-      setPopularError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to fetch popular runes',
-      );
-      setIsPopularLoading(false);
-    });
+    if (isPopularLoading) return;
+    let runes = basePopularRunes;
+    if (preSelectedAsset) {
+      const exists = runes.some((r) => r.id === preSelectedAsset.id);
+      if (!exists) runes = [preSelectedAsset, ...runes];
+    }
+    setPopularRunes(runes);
+    if (!preSelectedRune && !assetOut && runes.length > 0) {
+      const firstRune = safeArrayFirst(runes);
+      if (firstRune) setAssetOut(firstRune);
+    }
   }, [
-    cachedPopularRunes,
-    preSelectedRune,
+    basePopularRunes,
+    isPopularLoading,
     preSelectedAsset,
+    preSelectedRune,
     assetOut,
     setAssetOut,
   ]);


### PR DESCRIPTION
## Summary
- add `usePopularRunes` hook for cached popular rune data
- refactor borrow, swap, and search hooks to use `usePopularRunes`
- update components and tests for new popular rune handling

## Testing
- `npx pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6789ae608323b6c9d8a73e22461f