### PR TITLE
refactor(utils): add generic popular items mapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refactored popular rune mapping into a generic utility.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/utils/__tests__/popularRunes.test.ts
+++ b/src/utils/__tests__/popularRunes.test.ts
@@ -1,0 +1,43 @@
+import {
+  mapPopularItems,
+  mapPopularToAsset,
+  mapPopularToRune,
+} from '@/utils/popularRunes';
+
+describe('popular runes mappers', () => {
+  const items = [
+    {
+      token_id: '1',
+      token: 'AAA',
+      symbol: '',
+      icon: 'url1',
+      is_verified: true,
+    },
+    { id: '2', name: 'BBB', imageURI: 'url2' },
+  ];
+
+  it('maps items using a transformer', () => {
+    const result = mapPopularItems(items, ({ id, name }) => ({
+      value: id,
+      label: name,
+    }));
+    expect(result).toEqual([
+      { value: '1', label: 'AAA' },
+      { value: '2', label: 'BBB' },
+    ]);
+  });
+
+  it('maps items to Asset', () => {
+    expect(mapPopularToAsset(items)).toEqual([
+      { id: '1', name: 'AAA', imageURI: 'url1', isBTC: false },
+      { id: '2', name: 'BBB', imageURI: 'url2', isBTC: false },
+    ]);
+  });
+
+  it('maps items to Rune', () => {
+    expect(mapPopularToRune(items)).toEqual([
+      { id: '1', name: 'AAA', imageURI: 'url1' },
+      { id: '2', name: 'BBB', imageURI: 'url2' },
+    ]);
+  });
+});

--- a/src/utils/popularRunes.ts
+++ b/src/utils/popularRunes.ts
@@ -9,49 +9,42 @@ type PopularRuneItem = {
   is_verified: boolean;
 };
 
-// Convert popular rune items to Asset format (handles both our format and API response)
+type BasePopularItem = {
+  id: string;
+  name: string;
+  imageURI: string;
+};
+
+export const mapPopularItems = <T>(
+  items: PopularRuneItem[] | Record<string, unknown>[],
+  transform: (item: BasePopularItem) => T,
+): T[] =>
+  items.map((item) => {
+    const base: BasePopularItem = {
+      id: String(
+        (item as PopularRuneItem).token_id ||
+          (item as Record<string, unknown>).id ||
+          '',
+      ),
+      name: String(
+        (item as PopularRuneItem).token ||
+          (item as Record<string, unknown>).name ||
+          (item as Record<string, unknown>).rune ||
+          '',
+      ),
+      imageURI: String(
+        (item as PopularRuneItem).icon ||
+          (item as Record<string, unknown>).imageURI ||
+          '',
+      ),
+    };
+    return transform(base);
+  });
+
 export const mapPopularToAsset = (
   items: PopularRuneItem[] | Record<string, unknown>[],
-): Asset[] =>
-  items.map((item) => ({
-    id: String(
-      (item as PopularRuneItem).token_id ||
-        (item as Record<string, unknown>).id ||
-        '',
-    ),
-    name: String(
-      (item as PopularRuneItem).token ||
-        (item as Record<string, unknown>).name ||
-        (item as Record<string, unknown>).rune ||
-        '',
-    ),
-    imageURI: String(
-      (item as PopularRuneItem).icon ||
-        (item as Record<string, unknown>).imageURI ||
-        '',
-    ),
-    isBTC: false,
-  }));
+): Asset[] => mapPopularItems(items, (item) => ({ ...item, isBTC: false }));
 
-// Convert popular rune items to Rune format (handles both our format and API response)
 export const mapPopularToRune = (
   items: PopularRuneItem[] | Record<string, unknown>[],
-): Rune[] =>
-  items.map((item) => ({
-    id: String(
-      (item as PopularRuneItem).token_id ||
-        (item as Record<string, unknown>).id ||
-        '',
-    ),
-    name: String(
-      (item as PopularRuneItem).token ||
-        (item as Record<string, unknown>).name ||
-        (item as Record<string, unknown>).rune ||
-        '',
-    ),
-    imageURI: String(
-      (item as PopularRuneItem).icon ||
-        (item as Record<string, unknown>).imageURI ||
-        '',
-    ),
-  }));
+): Rune[] => mapPopularItems(items, (item) => item);


### PR DESCRIPTION
## Summary
- add generic `mapPopularItems` to normalize popular rune data
- reimplement asset and rune mappers using the generic helper
- cover generic and specific mappings with tests

## Testing
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa67997ac08323b42b4027ae74ebcb