### PR TITLE
refactor: reuse fee rate hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Made `useFeeRates` accept optional React Query config and reused it in swap execution.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/hooks/__tests__/useSwapExecution.test.ts
+++ b/src/hooks/__tests__/useSwapExecution.test.ts
@@ -7,14 +7,16 @@ import useSwapExecution from '@/hooks/useSwapExecution';
 jest.mock('@/lib/api', () => ({
   getPsbtFromApi: jest.fn(),
   confirmPsbtViaApi: jest.fn(),
-  fetchRecommendedFeeRates: jest.fn(),
-  QUERY_KEYS: { BTC_FEE_RATES: 'btcFeeRates' },
 }));
 
-jest.mock('@tanstack/react-query', () => ({ useQuery: jest.fn() }));
+jest.mock('@/hooks/useFeeRates', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
 
 const { getPsbtFromApi, confirmPsbtViaApi } = jest.requireMock('@/lib/api');
-const { useQuery } = jest.requireMock('@tanstack/react-query');
+const useFeeRates = jest.requireMock('@/hooks/useFeeRates')
+  .default as jest.Mock;
 
 type HookProps = Parameters<typeof useSwapExecution>[0];
 
@@ -42,7 +44,7 @@ const createBaseProps = (overrides: Partial<HookProps> = {}): HookProps => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
-  (useQuery as jest.Mock).mockReturnValue({
+  useFeeRates.mockReturnValue({
     data: { fastestFee: 5, halfHourFee: 5 },
   });
 });

--- a/src/hooks/useFeeRates.ts
+++ b/src/hooks/useFeeRates.ts
@@ -1,12 +1,16 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { QUERY_KEYS, fetchRecommendedFeeRates } from '@/lib/api';
+import type { BitcoinFeeRates } from '@/lib/api';
 
-export const useFeeRates = () =>
+export const useFeeRates = (
+  options?: Partial<UseQueryOptions<BitcoinFeeRates>>,
+) =>
   useQuery({
     queryKey: [QUERY_KEYS.BTC_FEE_RATES],
     queryFn: fetchRecommendedFeeRates,
     refetchOnWindowFocus: false,
     staleTime: 5 * 60 * 1000,
+    ...options,
   });
 
 export default useFeeRates;

--- a/src/hooks/useSwapExecution.ts
+++ b/src/hooks/useSwapExecution.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query';
 import { useRef } from 'react';
 import {
   type ConfirmPSBTParams,
@@ -10,12 +9,8 @@ import type {
   SwapProcessAction,
   SwapProcessState,
 } from '@/components/swap/SwapProcessManager';
-import {
-  QUERY_KEYS,
-  confirmPsbtViaApi,
-  fetchRecommendedFeeRates,
-  getPsbtFromApi,
-} from '@/lib/api';
+import { confirmPsbtViaApi, getPsbtFromApi } from '@/lib/api';
+import useFeeRates from '@/hooks/useFeeRates';
 import { logger } from '@/lib/logger';
 import { Asset } from '@/types/common';
 import { patchOrder } from '@/utils/orderUtils';
@@ -67,11 +62,7 @@ export default function useSwapExecution({
 }: UseSwapExecutionArgs) {
   const errorMessageRef = useRef<string | null>(null);
 
-  const { data: recommendedFeeRates } = useQuery({
-    queryKey: [QUERY_KEYS.BTC_FEE_RATES],
-    queryFn: fetchRecommendedFeeRates,
-    refetchOnWindowFocus: false,
-    staleTime: 5 * 60 * 1000,
+  const { data: recommendedFeeRates } = useFeeRates({
     gcTime: 10 * 60 * 1000,
   });
 


### PR DESCRIPTION
## Summary
- allow passing React Query options to `useFeeRates`
- use `useFeeRates` within `useSwapExecution`
- update swap execution tests for new hook

## Testing
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6843d994832391bd649b7436524d