### PR TITLE
refactor: replace console logs with logger utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Replace console statements with logger utilities.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/app/api/ordiscan/btc-balance/route.ts
+++ b/src/app/api/ordiscan/btc-balance/route.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
 import { getOrdiscanClient } from '@/lib/serverUtils';
 import { withApiHandler } from '@/lib/withApiHandler';
+import { logger } from '@/lib/logger';
 
 export const GET = withApiHandler(
   async (request: NextRequest) => {
@@ -17,9 +18,9 @@ export const GET = withApiHandler(
     const utxos = await ordiscan.address.getUtxos({ address: address });
 
     if (!Array.isArray(utxos)) {
-      console.warn(
+      logger.warn(
         `[API Route] Invalid or empty UTXO data received for address ${address}. Expected array, got:`,
-        utxos,
+        { utxos },
       );
       return createSuccessResponse({ balance: 0 });
     }

--- a/src/app/api/ordiscan/rune-info/route.ts
+++ b/src/app/api/ordiscan/rune-info/route.ts
@@ -4,6 +4,7 @@ import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
 import { getRuneData } from '@/lib/runesData';
 import { withApiHandler } from '@/lib/withApiHandler';
 import { normalizeRuneName } from '@/utils/runeUtils';
+import { logger } from '@/lib/logger';
 
 export const GET = withApiHandler(
   async (request: NextRequest) => {
@@ -22,7 +23,7 @@ export const GET = withApiHandler(
     const runeInfo = await getRuneData(formattedName);
 
     if (!runeInfo) {
-      console.warn(`[API Route] Rune info not found for ${formattedName}`);
+      logger.warn(`[API Route] Rune info not found for ${formattedName}`);
       // Return null data with success: true for consistent client-side handling
       return createSuccessResponse(null, 404);
     }

--- a/src/app/api/ordiscan/rune-market/route.ts
+++ b/src/app/api/ordiscan/rune-market/route.ts
@@ -4,6 +4,7 @@ import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
 import { getRuneMarketData } from '@/lib/runeMarketData';
 import { withApiHandler } from '@/lib/withApiHandler';
 import { normalizeRuneName } from '@/utils/runeUtils';
+import { logger } from '@/lib/logger';
 
 export const GET = withApiHandler(
   async (request: NextRequest) => {
@@ -17,7 +18,7 @@ export const GET = withApiHandler(
     const marketInfo = await getRuneMarketData(formattedName);
 
     if (!marketInfo) {
-      console.warn(
+      logger.warn(
         `[API Route] Rune market info not found for ${formattedName}`,
       );
       return createSuccessResponse(null, 404);

--- a/src/app/api/ordiscan/rune-update/route.ts
+++ b/src/app/api/ordiscan/rune-update/route.ts
@@ -9,6 +9,7 @@ import { RuneData } from '@/lib/runesData';
 import { getOrdiscanClient } from '@/lib/serverUtils';
 import { supabase } from '@/lib/supabase';
 import { withApiHandler } from '@/lib/withApiHandler';
+import { logger, logDbError } from '@/lib/logger';
 
 export const POST = withApiHandler(
   async (request: NextRequest) => {
@@ -21,7 +22,7 @@ export const POST = withApiHandler(
     const runeData = await ordiscan.rune.getInfo({ name: runeName });
 
     if (!runeData) {
-      console.warn(`[API Route] Rune info not found for ${runeName}`);
+      logger.warn(`[API Route] Rune info not found for ${runeName}`);
       return createSuccessResponse(null, 404);
     }
 
@@ -37,8 +38,8 @@ export const POST = withApiHandler(
       .select();
 
     if (updateError) {
-      console.error('[API Route] Error updating rune data:', updateError);
-      console.error('[API Route] Update error details:', {
+      logDbError('update rune data', updateError);
+      logger.error('[API Route] Update error details:', {
         code: updateError.code,
         message: updateError.message,
         details: updateError.details,

--- a/src/lib/__tests__/apiUtils.test.ts
+++ b/src/lib/__tests__/apiUtils.test.ts
@@ -6,6 +6,7 @@ import {
   handleApiError,
   validateRequest,
 } from '@/lib/apiUtils';
+import { logger } from '@/lib/logger';
 
 // Mock NextResponse.json
 jest.mock('next/server', () => ({
@@ -79,8 +80,8 @@ describe('createSuccessResponse', () => {
 describe('createErrorResponse', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    // Mock console.error to prevent test output pollution
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    // Mock logger.error to prevent test output pollution
+    jest.spyOn(logger, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -129,7 +130,7 @@ describe('createErrorResponse', () => {
     );
   });
 
-  it('logs error to console in non-test env', () => {
+  it('logs error via logger in non-test env', () => {
     const message = 'Error message';
     const prevEnv = process.env;
     try {
@@ -138,7 +139,7 @@ describe('createErrorResponse', () => {
         NODE_ENV: 'development',
       } as NodeJS.ProcessEnv;
       createErrorResponse(message);
-      expect(console.error).toHaveBeenCalledWith('[API Error] Error message');
+      expect(logger.error).toHaveBeenCalledWith('[API Error] Error message');
     } finally {
       process.env = prevEnv;
     }

--- a/src/lib/apiUtils.ts
+++ b/src/lib/apiUtils.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 /**
  * Creates a standardized success response object
@@ -34,7 +35,7 @@ export function createErrorResponse(
   if (process.env.NODE_ENV !== 'test') {
     const includeDetails = process.env.NODE_ENV !== 'production';
     const detailsPart = includeDetails && details ? `: ${details}` : '';
-    console.error(`[API Error] ${message}${detailsPart}`);
+    logger.error(`[API Error] ${message}${detailsPart}`);
   }
 
   return NextResponse.json(

--- a/src/lib/supabaseQueries.ts
+++ b/src/lib/supabaseQueries.ts
@@ -6,6 +6,7 @@
 import type { RuneMarketInfo } from '@/types/ordiscan';
 import type { RuneData } from '@/lib/runesData';
 import { supabase } from '@/lib/supabase';
+import { logDbError } from '@/lib/logger';
 
 // Types for database tables
 export interface RuneRecord {
@@ -52,7 +53,7 @@ export async function batchFetchRunes(
     .in('name', runeNames);
 
   if (error) {
-    console.warn('Error fetching runes from Supabase:', error);
+    logDbError('batchFetchRunes', error);
     return [];
   }
 
@@ -74,7 +75,7 @@ export async function batchFetchRuneMarketData(
     .gt('last_updated_at', new Date(Date.now() - 3600000).toISOString()); // Last hour
 
   if (error) {
-    console.warn('Error fetching rune market data from Supabase:', error);
+    logDbError('batchFetchRuneMarketData', error);
     return [];
   }
 
@@ -110,7 +111,7 @@ export async function upsertRuneData(runeData: RuneData): Promise<boolean> {
     .select();
 
   if (error) {
-    console.warn('Error upserting rune data:', error);
+    logDbError('upsertRuneData', error);
     return false;
   }
 
@@ -137,7 +138,7 @@ export async function upsertRuneMarketData(
     .upsert(upsertData, { onConflict: 'rune_name' });
 
   if (error) {
-    console.warn('Error upserting market data:', error);
+    logDbError('upsertRuneMarketData', error);
     return false;
   }
 
@@ -159,7 +160,7 @@ export async function fetchRuneByName(
   if (error) {
     if (error.code !== 'PGRST116') {
       // PGRST116 is "not found", which is expected
-      console.warn('Error fetching rune by name:', error);
+      logDbError('fetchRuneByName', error);
     }
     return null;
   }
@@ -185,7 +186,7 @@ export async function fetchRuneMarketDataByName(
 
   if (error) {
     if (error.code !== 'PGRST116') {
-      console.warn('Error fetching market data by name:', error);
+      logDbError('fetchRuneMarketDataByName', error);
     }
     return null;
   }
@@ -223,7 +224,7 @@ export async function batchUpsertRunes(runesData: RuneData[]): Promise<number> {
     .upsert(dataToInsert, { onConflict: 'name' });
 
   if (error) {
-    console.warn('Error batch upserting runes:', error);
+    logDbError('batchUpsertRunes', error);
     return 0;
   }
 
@@ -244,6 +245,6 @@ export async function cleanupOldMarketData(olderThanHours = 24): Promise<void> {
     .lt('last_updated_at', cutoffTime);
 
   if (error) {
-    console.warn('Error cleaning up old market data:', error);
+    logDbError('cleanupOldMarketData', error);
   }
 }


### PR DESCRIPTION
## Summary
- replace console calls with logger utilities across Supabase queries and Ordiscan API routes
- log API errors via logger in apiUtils
- update tests and changelog

## Testing
- `pnpm lint`
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa688f5bd48323b3ae1e8725f44c4d