### PR TITLE
refactor: use useRuneInfo hook in FormattedRuneName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refactored `FormattedRuneName` to use the `useRuneInfo` hook.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/components/formatters/FormattedRuneName.tsx
+++ b/src/components/formatters/FormattedRuneName.tsx
@@ -1,23 +1,15 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
 import React from 'react';
-import { fetchRuneInfoFromApi } from '@/lib/api';
-import type { RuneData } from '@/lib/runesData';
+import { useRuneInfo } from '@/hooks/useRuneInfo';
 
 interface FormattedRuneNameProps {
   runeName: string | null | undefined;
 }
 
 export function FormattedRuneName({ runeName }: FormattedRuneNameProps) {
-  // Use React Query to fetch rune info
-  const { data: runeInfo } = useQuery<RuneData | null, Error>({
-    queryKey: ['runeInfoApi', (runeName || '').toUpperCase()],
-    queryFn: () =>
-      runeName ? fetchRuneInfoFromApi(runeName) : Promise.resolve(null),
-    enabled: !!runeName && runeName !== 'N/A',
-    staleTime: Infinity, // Names rarely change, cache indefinitely
-    retry: 1, // Minimal retry to reduce network load
+  const { data: runeInfo } = useRuneInfo(runeName, {
+    enabled: runeName !== 'N/A',
   });
 
   // Handle invalid rune names


### PR DESCRIPTION
## Summary
- replace inline query in FormattedRuneName with useRuneInfo hook
- note refactor in changelog

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6dc6f1e883239c6f334c84229c9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated changelog to note an internal refactor related to rune name formatting; no public API changes.

* Refactor
  * Streamlined rune name formatting to use a shared data hook for consistency.
  * No changes to user-visible behavior: rune names display as before, including handling of invalid values.
  * Does not alter interfaces or configuration; existing usage continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->