### PR TITLE
feat: centralize sats terminal errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Centralized SatsTerminal error handler and wrapped PSBT endpoints with `withApiHandler`.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/app/api/sats-terminal/psbt/confirm/route.ts
+++ b/src/app/api/sats-terminal/psbt/confirm/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { ConfirmPSBTParams, Order } from 'satsterminal-sdk';
 import { z } from 'zod';
-import {
-  createErrorResponse,
-  handleApiError,
-  validateRequest,
-} from '@/lib/apiUtils';
+import { validateRequest } from '@/lib/apiUtils';
+import { handleSatsTerminalError } from '@/lib/satsTerminalError';
 import { getSatsTerminalClient } from '@/lib/serverUtils';
+import { withApiHandler } from '@/lib/withApiHandler';
 import { runeOrderSchema } from '@/types/satsTerminal';
 
 const confirmPsbtParamsSchema = z.object({
@@ -23,7 +21,7 @@ const confirmPsbtParamsSchema = z.object({
   rbfProtection: z.boolean().optional(),
 });
 
-export async function POST(request: NextRequest) {
+const handler = async (request: NextRequest) => {
   const validation = await validateRequest(
     request,
     confirmPsbtParamsSchema,
@@ -32,69 +30,31 @@ export async function POST(request: NextRequest) {
   if (!validation.success) return validation.errorResponse;
   const validatedParams = validation.data;
 
-  try {
-    const terminal = getSatsTerminalClient();
+  const terminal = getSatsTerminalClient();
 
-    // Convert to SDK-compatible format
-    const confirmParams: ConfirmPSBTParams = {
-      orders: validatedParams.orders as Order[],
-      address: validatedParams.address,
-      publicKey: validatedParams.publicKey,
-      paymentAddress: validatedParams.paymentAddress,
-      paymentPublicKey: validatedParams.paymentPublicKey,
-      signedPsbtBase64: validatedParams.signedPsbtBase64,
-      swapId: validatedParams.swapId,
-      runeName: validatedParams.runeName,
-      sell: validatedParams.sell ?? false,
-      rbfProtection: validatedParams.rbfProtection ?? false,
-      // Only include signedRbfPsbtBase64 if it has a valid value
-      ...(validatedParams.signedRbfPsbtBase64 && {
-        signedRbfPsbtBase64: validatedParams.signedRbfPsbtBase64,
-      }),
-    };
+  // Convert to SDK-compatible format
+  const confirmParams: ConfirmPSBTParams = {
+    orders: validatedParams.orders as Order[],
+    address: validatedParams.address,
+    publicKey: validatedParams.publicKey,
+    paymentAddress: validatedParams.paymentAddress,
+    paymentPublicKey: validatedParams.paymentPublicKey,
+    signedPsbtBase64: validatedParams.signedPsbtBase64,
+    swapId: validatedParams.swapId,
+    runeName: validatedParams.runeName,
+    sell: validatedParams.sell ?? false,
+    rbfProtection: validatedParams.rbfProtection ?? false,
+    // Only include signedRbfPsbtBase64 if it has a valid value
+    ...(validatedParams.signedRbfPsbtBase64 && {
+      signedRbfPsbtBase64: validatedParams.signedRbfPsbtBase64,
+    }),
+  };
 
-    const confirmResponse = await terminal.confirmPSBT(confirmParams);
-    return NextResponse.json(confirmResponse);
-  } catch (error) {
-    const errorInfo = handleApiError(error, 'Failed to confirm PSBT');
-    const errorMessage = error instanceof Error ? error.message : String(error);
+  const confirmResponse = await terminal.confirmPSBT(confirmParams);
+  return NextResponse.json(confirmResponse);
+};
 
-    // Special handling for quote expired
-    if (
-      errorInfo.message.includes('Quote expired') ||
-      (error &&
-        typeof error === 'object' &&
-        (error as { code?: string }).code === 'ERR677K3')
-    ) {
-      return createErrorResponse(
-        'Quote expired. Please fetch a new quote.',
-        errorInfo.details,
-        410,
-      );
-    }
-
-    // Special handling for rate limiting
-    if (errorMessage.includes('Rate limit') || errorInfo.status === 429) {
-      return createErrorResponse(
-        'Rate limit exceeded',
-        'Please try again later',
-        429,
-      );
-    }
-
-    // Handle unexpected token errors (HTML responses instead of JSON)
-    if (errorMessage.includes('Unexpected token')) {
-      return createErrorResponse(
-        'API service unavailable',
-        'The SatsTerminal API is currently unavailable. Please try again later.',
-        503,
-      );
-    }
-
-    return createErrorResponse(
-      errorInfo.message,
-      errorInfo.details,
-      errorInfo.status,
-    );
-  }
-}
+export const POST = withApiHandler(handler, {
+  defaultErrorMessage: 'Failed to confirm PSBT',
+  customErrorHandler: handleSatsTerminalError,
+});

--- a/src/app/api/sats-terminal/psbt/create/route.ts
+++ b/src/app/api/sats-terminal/psbt/create/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { GetPSBTParams, Order } from 'satsterminal-sdk';
 import { z } from 'zod';
-import {
-  createErrorResponse,
-  handleApiError,
-  validateRequest,
-} from '@/lib/apiUtils';
+import { validateRequest } from '@/lib/apiUtils';
+import { handleSatsTerminalError } from '@/lib/satsTerminalError';
 import { getSatsTerminalClient } from '@/lib/serverUtils';
+import { withApiHandler } from '@/lib/withApiHandler';
 import { runeOrderSchema } from '@/types/satsTerminal';
 
 const getPsbtParamsSchema = z.object({
@@ -22,7 +20,7 @@ const getPsbtParamsSchema = z.object({
   slippage: z.number().optional(),
 });
 
-export async function POST(request: NextRequest) {
+const handler = async (request: NextRequest) => {
   const validation = await validateRequest(
     request,
     getPsbtParamsSchema,
@@ -31,65 +29,27 @@ export async function POST(request: NextRequest) {
   if (!validation.success) return validation.errorResponse;
   const validatedParams = validation.data;
 
-  try {
-    const terminal = getSatsTerminalClient();
+  const terminal = getSatsTerminalClient();
 
-    // Convert to SDK-compatible format
-    const psbtParams: GetPSBTParams = {
-      orders: validatedParams.orders as Order[],
-      address: validatedParams.address,
-      publicKey: validatedParams.publicKey,
-      paymentAddress: validatedParams.paymentAddress,
-      paymentPublicKey: validatedParams.paymentPublicKey,
-      runeName: validatedParams.runeName,
-      sell: validatedParams.sell ?? false,
-      rbfProtection: validatedParams.rbfProtection ?? false,
-      feeRate: validatedParams.feeRate ?? 1,
-      slippage: validatedParams.slippage ?? 0,
-    };
+  // Convert to SDK-compatible format
+  const psbtParams: GetPSBTParams = {
+    orders: validatedParams.orders as Order[],
+    address: validatedParams.address,
+    publicKey: validatedParams.publicKey,
+    paymentAddress: validatedParams.paymentAddress,
+    paymentPublicKey: validatedParams.paymentPublicKey,
+    runeName: validatedParams.runeName,
+    sell: validatedParams.sell ?? false,
+    rbfProtection: validatedParams.rbfProtection ?? false,
+    feeRate: validatedParams.feeRate ?? 1,
+    slippage: validatedParams.slippage ?? 0,
+  };
 
-    const psbtResponse = await terminal.getPSBT(psbtParams);
-    return NextResponse.json(psbtResponse);
-  } catch (error) {
-    const errorInfo = handleApiError(error, 'Failed to generate PSBT');
-    const errorMessage = error instanceof Error ? error.message : String(error);
+  const psbtResponse = await terminal.getPSBT(psbtParams);
+  return NextResponse.json(psbtResponse);
+};
 
-    // Special handling for quote expired
-    if (
-      errorInfo.message.includes('Quote expired') ||
-      (error &&
-        typeof error === 'object' &&
-        (error as { code?: string }).code === 'ERR677K3')
-    ) {
-      return createErrorResponse(
-        'Quote expired. Please fetch a new quote.',
-        errorInfo.details,
-        410,
-      );
-    }
-
-    // Special handling for rate limiting
-    if (errorMessage.includes('Rate limit') || errorInfo.status === 429) {
-      return createErrorResponse(
-        'Rate limit exceeded',
-        'Please try again later',
-        429,
-      );
-    }
-
-    // Handle unexpected token errors (HTML responses instead of JSON)
-    if (errorMessage.includes('Unexpected token')) {
-      return createErrorResponse(
-        'API service unavailable',
-        'The SatsTerminal API is currently unavailable. Please try again later.',
-        503,
-      );
-    }
-
-    return createErrorResponse(
-      errorInfo.message,
-      errorInfo.details,
-      errorInfo.status,
-    );
-  }
-}
+export const POST = withApiHandler(handler, {
+  defaultErrorMessage: 'Failed to generate PSBT',
+  customErrorHandler: handleSatsTerminalError,
+});

--- a/src/lib/satsTerminalError.ts
+++ b/src/lib/satsTerminalError.ts
@@ -1,0 +1,41 @@
+import { createErrorResponse, handleApiError } from '@/lib/apiUtils';
+import type { NextResponse } from 'next/server';
+
+/**
+ * Handles known SatsTerminal API error cases
+ */
+export function handleSatsTerminalError(error: unknown): NextResponse | null {
+  const errorInfo = handleApiError(error, 'SatsTerminal error');
+  const errorMessage = error instanceof Error ? error.message : String(error);
+
+  if (
+    errorInfo.message.includes('Quote expired') ||
+    (error &&
+      typeof error === 'object' &&
+      (error as { code?: string }).code === 'ERR677K3')
+  ) {
+    return createErrorResponse(
+      'Quote expired. Please fetch a new quote.',
+      errorInfo.details,
+      410,
+    );
+  }
+
+  if (errorMessage.includes('Rate limit') || errorInfo.status === 429) {
+    return createErrorResponse(
+      'Rate limit exceeded',
+      'Please try again later',
+      429,
+    );
+  }
+
+  if (errorMessage.includes('Unexpected token')) {
+    return createErrorResponse(
+      'API service unavailable',
+      'The SatsTerminal API is currently unavailable. Please try again later.',
+      503,
+    );
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- centralize SatsTerminal error mapping in `handleSatsTerminalError`
- wrap PSBT create and confirm routes with `withApiHandler`
- document new error handling utility in changelog

## Testing
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68aa6e0cbec083238c192adcfab77efe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Standardized API error responses for PSBT create/confirm endpoints with clearer messages and accurate status codes.
  - Added specific handling for expired quotes (410), rate limits (429), and temporary service issues (503).

- Refactor
  - Centralized error handling across PSBT endpoints for more predictable behavior and consistency.

- Documentation
  - Updated changelog with an Unreleased entry noting centralized SatsTerminal error handling and wrapping of PSBT endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->