### PR TITLE
refactor: centralize rune route validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Centralized rune route validation with shared helper.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/app/api/ordiscan/helpers.ts
+++ b/src/app/api/ordiscan/helpers.ts
@@ -1,0 +1,31 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
+import { validators } from '@/lib/validationSchemas';
+import { withApiHandler } from '@/lib/withApiHandler';
+import { normalizeRuneName } from '@/utils/runeUtils';
+
+export function createRuneRoute<T>(
+  fetcher: (rune: string) => Promise<T | null>,
+  errorMessage: string,
+) {
+  return withApiHandler(
+    async (request: NextRequest) => {
+      const schema = z.object({ name: validators.runeName });
+      const validation = await validateRequest(request, schema, 'query');
+      if (!validation.success) return validation.errorResponse;
+      const { name } = validation.data;
+
+      const normalized = normalizeRuneName(name);
+      const data = await fetcher(normalized);
+
+      if (!data) {
+        console.warn(`[API Route] ${errorMessage}: ${normalized} not found`);
+        return createSuccessResponse(null, 404);
+      }
+
+      return createSuccessResponse(data);
+    },
+    { defaultErrorMessage: errorMessage },
+  );
+}

--- a/src/app/api/ordiscan/rune-info/route.ts
+++ b/src/app/api/ordiscan/rune-info/route.ts
@@ -1,33 +1,4 @@
-import { NextRequest } from 'next/server';
-import { z } from 'zod';
-import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
 import { getRuneData } from '@/lib/runesData';
-import { withApiHandler } from '@/lib/withApiHandler';
-import { normalizeRuneName } from '@/utils/runeUtils';
+import { createRuneRoute } from '@/app/api/ordiscan/helpers';
 
-export const GET = withApiHandler(
-  async (request: NextRequest) => {
-    // const { searchParams } = new URL(request.url);
-    // const name = searchParams.get('name');
-
-    // Zod validation for 'name'
-    const schema = z.object({ name: z.string().min(1) });
-    const validation = await validateRequest(request, schema, 'query');
-    if (!validation.success) return validation.errorResponse;
-    const { name: validName } = validation.data;
-
-    // Ensure name doesn't have spacers for the API call
-    const formattedName = normalizeRuneName(validName);
-
-    const runeInfo = await getRuneData(formattedName);
-
-    if (!runeInfo) {
-      console.warn(`[API Route] Rune info not found for ${formattedName}`);
-      // Return null data with success: true for consistent client-side handling
-      return createSuccessResponse(null, 404);
-    }
-
-    return createSuccessResponse(runeInfo);
-  },
-  { defaultErrorMessage: 'Failed to fetch rune info' },
-);
+export const GET = createRuneRoute(getRuneData, 'Failed to fetch rune info');

--- a/src/app/api/ordiscan/rune-market/route.ts
+++ b/src/app/api/ordiscan/rune-market/route.ts
@@ -1,29 +1,7 @@
-import { NextRequest } from 'next/server';
-import { z } from 'zod';
-import { createSuccessResponse, validateRequest } from '@/lib/apiUtils';
 import { getRuneMarketData } from '@/lib/runeMarketData';
-import { withApiHandler } from '@/lib/withApiHandler';
-import { normalizeRuneName } from '@/utils/runeUtils';
+import { createRuneRoute } from '@/app/api/ordiscan/helpers';
 
-export const GET = withApiHandler(
-  async (request: NextRequest) => {
-    const schema = z.object({ name: z.string().min(1) });
-    const validation = await validateRequest(request, schema, 'query');
-    if (!validation.success) return validation.errorResponse;
-    const { name: validName } = validation.data;
-
-    const formattedName = normalizeRuneName(validName);
-
-    const marketInfo = await getRuneMarketData(formattedName);
-
-    if (!marketInfo) {
-      console.warn(
-        `[API Route] Rune market info not found for ${formattedName}`,
-      );
-      return createSuccessResponse(null, 404);
-    }
-
-    return createSuccessResponse(marketInfo);
-  },
-  { defaultErrorMessage: 'Failed to fetch market info' },
+export const GET = createRuneRoute(
+  getRuneMarketData,
+  'Failed to fetch market info',
 );


### PR DESCRIPTION
## Summary
- add generic `createRuneRoute` helper for rune name validation
- refactor rune info and market routes to use helper
- document rune route helper in changelog

## Testing
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68aa6ddb97608323b3aaab4de73bd5db