### PR TITLE
feat: add reusable rune balances hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Reusable `useRuneBalances` hook for fetching rune balances and refactored Borrow and Swap tabs to use it.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added

--- a/src/components/borrow/BorrowTab.tsx
+++ b/src/components/borrow/BorrowTab.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
-//
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import React, { useState } from 'react';
@@ -12,9 +10,8 @@ import { useLiquidiumAuth } from '@/hooks/useLiquidiumAuth';
 import { useRuneBalance } from '@/hooks/useRuneBalance';
 import { useRuneInfo } from '@/hooks/useRuneInfo';
 import { useRuneMarketData } from '@/hooks/useRuneMarketData';
-import { QUERY_KEYS, fetchRuneBalancesFromApi } from '@/lib/api';
+import { useRuneBalances } from '@/hooks/useRuneBalances';
 import { Asset } from '@/types/common';
-import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
 import { percentageOfRawAmount } from '@/utils/runeFormatting';
 import { formatUsd, parseAmount, sanitizeForBig } from '@/utils/formatters';
 import Big from 'big.js';
@@ -73,15 +70,11 @@ export function BorrowTab({
   const [collateralAmount, setCollateralAmount] = useState('');
   const [feeRate, setFeeRate] = useState(0);
 
-  const { data: runeBalances, isLoading: isRuneBalancesLoading } = useQuery<
-    OrdiscanRuneBalance[],
-    Error
-  >({
-    queryKey: [QUERY_KEYS.RUNE_BALANCES, address],
-    queryFn: () => fetchRuneBalancesFromApi(address!),
-    enabled: !!connected && !!address,
-    staleTime: 30000,
-  });
+  const { data: runeBalances, isLoading: isRuneBalancesLoading } =
+    useRuneBalances(address, {
+      enabled: !!connected && !!address,
+      staleTime: 30000,
+    });
 
   const { data: collateralRuneInfo, isLoading: isCollateralRuneInfoLoading } =
     useRuneInfo(collateralAsset?.isBTC ? null : collateralAsset?.name, {

--- a/src/components/swap/SwapTab.tsx
+++ b/src/components/swap/SwapTab.tsx
@@ -12,9 +12,9 @@ import useSwapExecution from '@/hooks/useSwapExecution';
 import useSwapQuote from '@/hooks/useSwapQuote';
 import useSwapRunes from '@/hooks/useSwapRunes';
 import useUsdValues from '@/hooks/useUsdValues';
-import { fetchBtcBalanceFromApi, fetchRuneBalancesFromApi } from '@/lib/api';
+import { fetchBtcBalanceFromApi } from '@/lib/api';
+import { useRuneBalances } from '@/hooks/useRuneBalances';
 import { Asset, BTC_ASSET } from '@/types/common';
-import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
 import {
   formatAmountWithPrecision,
   percentageOfRawAmount,
@@ -158,11 +158,9 @@ export function SwapTab({
     data: runeBalances,
     isLoading: isRuneBalancesLoading,
     error: runeBalancesError,
-  } = useQuery<OrdiscanRuneBalance[], Error>({
-    queryKey: ['runeBalancesApi', address],
-    queryFn: () => fetchRuneBalancesFromApi(address!), // Use API function
-    enabled: !!connected && !!address, // Only run query if connected and address exists
-    staleTime: 30000, // Consider balances stale after 30 seconds
+  } = useRuneBalances(address, {
+    enabled: !!connected && !!address,
+    staleTime: 30000,
   });
 
   // Use shared hook for Input Rune Info

--- a/src/hooks/useRuneBalances.ts
+++ b/src/hooks/useRuneBalances.ts
@@ -1,0 +1,24 @@
+import {
+  useQuery,
+  type UseQueryOptions,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { QUERY_KEYS, fetchRuneBalancesFromApi } from '@/lib/api';
+import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
+
+export function useRuneBalances(
+  address: string | null,
+  options?: Omit<
+    UseQueryOptions<OrdiscanRuneBalance[], Error>,
+    'queryKey' | 'queryFn'
+  >,
+): UseQueryResult<OrdiscanRuneBalance[], Error> {
+  return useQuery<OrdiscanRuneBalance[], Error>({
+    queryKey: [QUERY_KEYS.RUNE_BALANCES, address],
+    queryFn: () => fetchRuneBalancesFromApi(address || ''),
+    enabled: !!address,
+    ...options,
+  });
+}
+
+export default useRuneBalances;


### PR DESCRIPTION
## Summary
- add useRuneBalances hook wrapping rune balance query
- refactor BorrowTab and SwapTab to use useRuneBalances
- document hook in changelog

## Testing
- `pnpm ai-check`

------
https://chatgpt.com/codex/tasks/task_e_68aa6da0e95c8323a579c38312c0047a