### PR TITLE
ci: auto-trigger @claude for missing changelog + grant commit perms

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -76,7 +76,7 @@ jobs:
           # Emit a multi-line reasons output
           printf 'reasons<<REASONS\n%s\nREASONS\n' "$reasons" >> "$GITHUB_OUTPUT"
 
-      - name: Comment guidance on PR
+      - name: Comment guidance on PR (and trigger Claude)
         if: ${{ steps.check.outputs.invalid == 'true' }}
         continue-on-error: true
         uses: actions/github-script@v7
@@ -122,7 +122,10 @@ jobs:
               '❌ Changelog validation failed:',
               reasons.trim(),
               '',
-              'Copy-paste prompt for your AI agent:',
+              // Trigger Claude to auto-fix by committing the changelog and version bump
+              '@claude Please generate and commit the missing changelog and version bump for this PR. Use the prompt below exactly as instructions. Push a single commit to this PR branch.',
+              '',
+              'Prompt for Claude:',
               '',
               '```text',
               prompt,

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,9 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Do not run this review when the workflow file itself is being modified
-    paths-ignore:
-      - ".github/workflows/claude-code-review.yml"
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -15,10 +12,6 @@ on:
 
 jobs:
   claude-review:
-    # Skip when Claude bot is the actor/sender to keep CI green on auto-commit PR bumps
-    if: |
-      github.actor != 'claude[bot]' &&
-      (github.event.sender.login != 'claude[bot]')
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -41,10 +34,6 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
-        # Make review non-blocking to keep CI clean even on transient provider/auth quirks
-        continue-on-error: true
-        # Extra safety: never fail the workflow if a bot somehow triggers this step
-        continue-on-error: ${{ github.actor == 'claude[bot]' || github.event.sender.login == 'claude[bot]' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -86,3 +75,4 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
+

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,9 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
+    # Do not run this review when the workflow file itself is being modified
+    paths-ignore:
+      - ".github/workflows/claude-code-review.yml"
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -38,6 +41,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
+        # Make review non-blocking to keep CI clean even on transient provider/auth quirks
+        continue-on-error: true
         # Extra safety: never fail the workflow if a bot somehow triggers this step
         continue-on-error: ${{ github.actor == 'claude[bot]' || github.event.sender.login == 'claude[bot]' }}
         with:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   claude-review:
+    # Skip when Claude bot is the actor/sender to keep CI green on auto-commit PR bumps
+    if: |
+      github.actor != 'claude[bot]' &&
+      (github.event.sender.login != 'claude[bot]')
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -34,6 +38,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
+        # Extra safety: never fail the workflow if a bot somehow triggers this step
+        continue-on-error: ${{ github.actor == 'claude[bot]' || github.event.sender.login == 'claude[bot]' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -75,4 +81,3 @@ jobs:
           # if: |
           #   !contains(github.event.pull_request.title, '[skip-review]') &&
           #   !contains(github.event.pull_request.title, '[WIP]')
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -16,11 +16,23 @@ jobs:
       (
         github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association)
+        (
+          contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association) ||
+          (
+            github.event.comment.user.login == 'github-actions[bot]' &&
+            contains(github.event.comment.body, '<!-- changelog-validate -->')
+          )
+        )
       ) || (
         github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
-        contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association)
+        (
+          contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association) ||
+          (
+            github.event.comment.user.login == 'github-actions[bot]' &&
+            contains(github.event.comment.body, '<!-- changelog-validate -->')
+          )
+        )
       ) || (
         github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
@@ -35,6 +47,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: read
+      id-token: write
       actions: read # Allows Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -44,8 +57,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # Pin action to a specific commit for supply-chain safety
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
+        uses: anthropics/claude-code-action@beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,16 +13,28 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains('OWNER,COLLABORATOR,MEMBER', github.event.comment.author_association)
+      ) || (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains('OWNER,COLLABORATOR,MEMBER', github.event.review.author_association)
+      ) || (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        contains('OWNER,COLLABORATOR,MEMBER', github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
       issues: read
-      id-token: write
       actions: read # Allows Claude to read CI results on PRs
     steps:
       - name: Checkout repository
@@ -32,7 +44,8 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        # Pin action to a specific commit for supply-chain safety
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,11 +19,11 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
-      actions: read # Required for Claude to read CI results on PRs
+      actions: read # Allows Claude to read CI results on PRs
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -61,4 +61,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2025-08-28
+
+### Changed
+
+- Updated changelog workflow to automatically trigger @claude when changelog validation fails, enabling automated changelog generation.
+- Enhanced Claude workflow permissions to allow contents and pull-requests write access for committing changelog updates.
+
 ## [0.2.3] - 2025-08-24
 
 ### Added
@@ -128,6 +135,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release: swap interface, price chart, core API routes and foundational UI.
+[0.2.4]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.3...v0.2.4
+[0.2.3]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.5...v0.2.0
@@ -137,4 +146,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ropl-btc/RunesSwap.app/releases/tag/v0.1.0
-[0.2.3]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.2...v0.2.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runesswap.app",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --runInBand",


### PR DESCRIPTION
This PR updates the changelog gate to automatically tag @claude with an execution-ready prompt when the changelog check fails.\n\n- Adds @claude trigger with the existing prompt so Claude can commit a single fix to the PR branch.\n- Updates Claude workflow permissions to contents/pull-requests write so commits can be pushed.\n\nIf CI fails on changelog, the bot comment should now wake Claude and have it fix the PR in one go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - CI now auto-generates and commits missing changelog and version bump when validation fails.
- Documentation
  - Added changelog entry for version 0.2.4.
- Chores
  - Tightened automation security: restricted triggers to organization members, upgraded permissions where needed, and pinned third-party actions for supply-chain safety.
  - Minor workflow label and formatting updates.
  - Version bumped to 0.2.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->