### PR TITLE
docs: CI test for review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -15,10 +15,8 @@ on:
 
 jobs:
   claude-review:
-    # Skip when Claude bot is the actor/sender to keep CI green on auto-commit PR bumps
-    if: |
-      github.actor != 'claude[bot]' &&
-      (github.event.sender.login != 'claude[bot]')
+    # Skip when Claude bot is the actor to keep CI green on auto-commit PR bumps
+    if: github.actor != 'claude[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -43,8 +41,6 @@ jobs:
         uses: anthropics/claude-code-action@beta
         # Make review non-blocking to keep CI clean even on transient provider/auth quirks
         continue-on-error: true
-        # Extra safety: never fail the workflow if a bot somehow triggers this step
-        continue-on-error: ${{ github.actor == 'claude[bot]' || github.event.sender.login == 'claude[bot]' }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -114,3 +114,6 @@ runs linting, tests and a production build. Please ensure:
 ## License
 
 MIT © RunesSwap.app
+
+
+> CI test: verify Claude review is non-blocking and bot-skipped.


### PR DESCRIPTION
Adds a small README note to exercise the updated Claude review workflow (skip bot, non-blocking step). Targeting the parent branch to avoid touching default-branch workflows.