### PR TITLE
refactor(hooks): migrate useSearchWithPopular to React Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactored `useSearchWithPopular` hook to use React Query for search and popular rune flows with debounced input.
 - Updated tests to wrap hook consumers with `QueryClientProvider`.
 
+### Fixed
+
+- useSearchWithPopular: prefer fetched popular results over `initialItems` when available; correct `isLoading`/`error` derivation; sync cache only when `initialItems` change.
+
 ## [0.2.5] - 2025-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2025-08-28
+
+### Changed
+
+- Refactored `useSearchWithPopular` hook to use React Query for search and popular rune flows with debounced input.
+- Updated tests to wrap hook consumers with `QueryClientProvider`.
+
 ## [0.2.5] - 2025-08-28
 
 ### Added
@@ -164,3 +171,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.1]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ropl-btc/RunesSwap.app/releases/tag/v0.1.0
 [0.2.5]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.4...v0.2.5
+[0.2.6]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.5...v0.2.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runesswap.app",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --runInBand",

--- a/src/components/swap/__tests__/InputArea.test.tsx
+++ b/src/components/swap/__tests__/InputArea.test.tsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { BTC_ASSET } from '@/types/common';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import InputArea from '@/components/swap/InputArea';
 
 jest.mock('next/image', () => ({
@@ -16,18 +17,25 @@ jest.mock('next/image', () => ({
 describe('InputArea', () => {
   it('renders with assetSelectorEnabled and no onAssetChange', () => {
     expect(() => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
       renderToString(
-        React.createElement(InputArea, {
-          label: 'Label',
-          inputId: 'input',
-          inputValue: '',
-          onInputChange: () => {}, // Add mock onChange to prevent React warning
-          assetSelectorEnabled: true,
-          selectedAsset: BTC_ASSET,
-          availableAssets: [BTC_ASSET],
-          onPercentageClick: undefined,
-          errorMessage: undefined,
-        }),
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(InputArea, {
+            label: 'Label',
+            inputId: 'input',
+            inputValue: '',
+            onInputChange: () => {}, // Add mock onChange to prevent React warning
+            assetSelectorEnabled: true,
+            selectedAsset: BTC_ASSET,
+            availableAssets: [BTC_ASSET],
+            onPercentageClick: undefined,
+            errorMessage: undefined,
+          }),
+        ),
       );
     }).not.toThrow();
   });

--- a/src/hooks/__tests__/useRunesSearch.test.tsx
+++ b/src/hooks/__tests__/useRunesSearch.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import useRunesSearch from '@/hooks/useRunesSearch';
 
 jest.mock('@/lib/api', () => ({
@@ -34,9 +35,15 @@ describe('useRunesSearch', () => {
     }));
 
     type Props = { cachedPopularRunes: Record<string, unknown>[] };
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
     const { result, rerender } = renderHook(
       (props: Props) => useRunesSearch(props),
-      { initialProps: { cachedPopularRunes: runes1 } },
+      { initialProps: { cachedPopularRunes: runes1 }, wrapper },
     );
     expect(result.current.availableRunes.map((r) => r.id)).toEqual(['123:1']);
 


### PR DESCRIPTION
Summary
- Refactor useSearchWithPopular to use @tanstack/react-query for both search and popular flows.
- Debounce the input and enable the query only when the trimmed query is non-empty (enabled: !!trimmed) per TanStack docs.
- Keep initialItems as the immediate source for popular results (so cached popular runes render instantly), and sync the popular cache via queryClient.setQueryData when props change.
- Update tests to wrap components/hooks in QueryClientProvider.

Why
- Aligns with CLAUDE.md guidance to use React Query for server data fetching.
- Gains caching, deduplication, background refetching and DevTools integration.

Implementation highlights
- Search query: queryKey ['search', trimmed], enabled: !!trimmed, queryFn returns mapped results.
- Popular query: queryKey ['popular-items'], seeded with initialItems (when provided) via initialData, and stays disabled while searching.
- When not searching and initialItems change, we push them into the cache with setQueryData to keep results in sync.
- Results/isLoading/error are composed to preserve existing UX (instant cached popular items when present; debounced search otherwise).

Tests
- Updated tests to provide a QueryClientProvider (TanStack requirement).
- Jest + type-check pass locally.

Docs (Context7 references)
- useQuery and enabled: https://github.com/tanstack/query/blob/main/docs/framework/react/guides/disabling-queries.md
- staleTime/gcTime guidance: https://github.com/tanstack/query/blob/main/docs/framework/react/guides/ssr.md and https://github.com/tanstack/query/blob/main/docs/framework/react/guides/migrating-to-v5.md
- useQuery reference: https://github.com/tanstack/query/blob/main/docs/framework/react/reference/useQuery.md

Notes
- This is a minimal, drop-in change. API of useSearchWithPopular remains the same.
- No behavioral changes for consumers beyond improved caching/dedup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search shows popular results when query is empty, supports preloaded initial items, clear/reset action, and finer debounce/control for input behavior.
  * Hook made more configurable for varied data sources and behaviors.

* **Refactor**
  * Search and popular flows unified under a consistent data-fetching approach for more reliable, performant results and clearer loading/error handling.

* **Tests**
  * Tests updated to provide required data-fetching context.

* **Chores**
  * Version bumped to 0.2.6 and changelog updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->