### PR TITLE
refactor(hooks): migrate useSearchWithPopular to React Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.6] - 2025-08-28
+
+### Changed
+
+- Refactored `useSearchWithPopular` hook to use React Query for search and popular rune flows with debounced input.
+- Updated tests to wrap hook consumers with `QueryClientProvider`.
+
 ## [0.2.5] - 2025-08-28
 
 ### Added
@@ -164,3 +171,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.1]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ropl-btc/RunesSwap.app/releases/tag/v0.1.0
 [0.2.5]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.4...v0.2.5
+[0.2.6]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.5...v0.2.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runesswap.app",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --runInBand",


### PR DESCRIPTION
## Summary
- bump version to 0.2.6
- document React Query refactor in changelog

## Testing
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68affbe8c9488323b62bedd8d1602316