### PR TITLE
refactor: simplify rune balances hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Refactored `useRuneBalances` to use the shared `useApiQuery` wrapper for balance fetching.
+
 ## [0.2.5] - 2025-08-28
 
 ### Added

--- a/src/hooks/useRuneBalance.ts
+++ b/src/hooks/useRuneBalance.ts
@@ -8,7 +8,7 @@ import { normalizeRuneName } from '@/utils/runeUtils';
  */
 export function useRuneBalance(
   runeName: string | undefined,
-  runeBalances: OrdiscanRuneBalance[] | undefined,
+  runeBalances: OrdiscanRuneBalance[] | null | undefined,
 ): string | null {
   return useMemo(() => {
     if (!runeName || !runeBalances) return null;

--- a/src/hooks/useRuneBalances.ts
+++ b/src/hooks/useRuneBalances.ts
@@ -1,24 +1,33 @@
-import {
-  useQuery,
-  type UseQueryOptions,
-  type UseQueryResult,
-} from '@tanstack/react-query';
+import { useApiQuery } from '@/hooks/useApiQuery';
 import { QUERY_KEYS, fetchRuneBalancesFromApi } from '@/lib/api';
 import { type RuneBalance as OrdiscanRuneBalance } from '@/types/ordiscan';
 
+interface UseRuneBalancesOptions {
+  enabled?: boolean;
+  staleTime?: number;
+  retry?: number;
+}
+
 export function useRuneBalances(
-  address: string | null,
-  options?: Omit<
-    UseQueryOptions<OrdiscanRuneBalance[], Error>,
-    'queryKey' | 'queryFn'
-  >,
-): UseQueryResult<OrdiscanRuneBalance[], Error> {
-  return useQuery<OrdiscanRuneBalance[], Error>({
-    queryKey: [QUERY_KEYS.RUNE_BALANCES, address],
-    queryFn: () => fetchRuneBalancesFromApi(address || ''),
-    enabled: !!address,
-    ...options,
-  });
+  address: string | null | undefined,
+  options: UseRuneBalancesOptions = {},
+) {
+  const { enabled, staleTime, retry } = options;
+  const config: { enabled?: boolean; retry?: number } = {};
+  if (enabled !== undefined) {
+    config.enabled = enabled;
+  }
+  if (retry !== undefined) {
+    config.retry = retry;
+  }
+
+  return useApiQuery<OrdiscanRuneBalance[]>(
+    QUERY_KEYS.RUNE_BALANCES,
+    address,
+    fetchRuneBalancesFromApi,
+    staleTime,
+    config,
+  );
 }
 
 export default useRuneBalances;


### PR DESCRIPTION
## Summary
- refactor `useRuneBalances` to leverage `useApiQuery`
- allow `useRuneBalance` to handle null balance arrays
- document refactor in changelog

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm ai-check`


------
https://chatgpt.com/codex/tasks/task_e_68affc9e512c8323a6e4d1310a63109f