### PR TITLE
fix: handle no-order quote errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Quote display formatting now stays in Big.js to avoid precision loss; BTC balance display uses Big-based formatter.
 - PSBT confirmation error handling uses typed guards and proper 4xx responses instead of ad-hoc Response casting.
 - CI: pnpm is set up before the Node cache to keep pnpm caching effective.
+- Swap quotes now map "no orders" errors reliably and surface a friendly message instead of crashing.
 
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@
 - Quote display formatting now stays in Big.js to avoid precision loss; BTC balance display uses Big-based formatter.
 - PSBT confirmation error handling uses typed guards and proper 4xx responses instead of ad-hoc Response casting.
 - CI: pnpm is set up before the Node cache to keep pnpm caching effective.
-- Swap quotes now map "no orders" errors reliably and surface a friendly message instead of crashing.
 
 All notable changes to this project will be documented in this file.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## [0.2.8] - 2025-12-29
+
+### Fixed
+- Swap quote errors for missing orders/liquidity now resolve to friendly messages without crashing the UI.
+- API client now throws when a success response is missing expected data.
+
 ## [0.2.7] - 2025-12-29
 
 ### Added
@@ -208,7 +214,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial release: swap interface, price chart, core API routes and foundational UI.
-[Unreleased]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.6...v0.2.7
 [0.2.4]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.2...v0.2.3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runesswap.app",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "scripts": {
     "test": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --runInBand",

--- a/src/hooks/useSwapQuote.ts
+++ b/src/hooks/useSwapQuote.ts
@@ -164,18 +164,31 @@ export function useSwapQuote({
         let errorMessage =
           err instanceof Error ? err.message : 'Failed to fetch quote';
 
+        const lowerMessage = errorMessage.toLowerCase();
+
         if (
+          lowerMessage.includes('liquidity') ||
+          lowerMessage.includes('no liquidity')
+        ) {
+          errorMessage =
+            'No liquidity available for this trade. Try a different amount or rune.';
+        } else if (
+          errorMessage.includes('No orders available') ||
+          errorMessage.includes('No valid orders') ||
+          lowerMessage.includes('no marketplace found') ||
+          errorMessage.includes('404')
+        ) {
+          errorMessage =
+            'No orders available for this trade. Try a different amount or rune.';
+        } else if (
           errorMessage.includes('500') ||
           errorMessage.includes('Internal Server Error')
         ) {
           errorMessage =
             'Server error: The quote service is temporarily unavailable. Please try again later.';
-        } else if (errorMessage.includes('No valid orders')) {
-          errorMessage =
-            'No orders available for this trade. Try a different amount or rune.';
         } else if (
-          errorMessage.includes('timeout') ||
-          errorMessage.includes('network')
+          lowerMessage.includes('timeout') ||
+          lowerMessage.includes('network')
         ) {
           errorMessage =
             'Network error: Please check your connection and try again.';
@@ -196,6 +209,7 @@ export function useSwapQuote({
           type: 'FETCH_QUOTE_ERROR',
           error: errorMessage,
         });
+        setQuoteTimestamp(null);
       }
     }
   }, [

--- a/src/hooks/useSwapQuote.ts
+++ b/src/hooks/useSwapQuote.ts
@@ -173,8 +173,8 @@ export function useSwapQuote({
           errorMessage =
             'No liquidity available for this trade. Try a different amount or rune.';
         } else if (
-          errorMessage.includes('No orders available') ||
-          errorMessage.includes('No valid orders') ||
+          lowerMessage.includes('no orders available') ||
+          lowerMessage.includes('no valid orders') ||
           lowerMessage.includes('no marketplace found') ||
           errorMessage.includes('404')
         ) {
@@ -182,7 +182,7 @@ export function useSwapQuote({
             'No orders available for this trade. Try a different amount or rune.';
         } else if (
           errorMessage.includes('500') ||
-          errorMessage.includes('Internal Server Error')
+          lowerMessage.includes('internal server error')
         ) {
           errorMessage =
             'Server error: The quote service is temporarily unavailable. Please try again later.';

--- a/src/hooks/useSwapQuote.ts
+++ b/src/hooks/useSwapQuote.ts
@@ -166,22 +166,19 @@ export function useSwapQuote({
 
         const lowerMessage = errorMessage.toLowerCase();
 
-        if (
-          lowerMessage.includes('liquidity') ||
-          lowerMessage.includes('no liquidity')
-        ) {
+        if (lowerMessage.includes('liquidity')) {
           errorMessage =
             'No liquidity available for this trade. Try a different amount or rune.';
         } else if (
           lowerMessage.includes('no orders available') ||
           lowerMessage.includes('no valid orders') ||
           lowerMessage.includes('no marketplace found') ||
-          errorMessage.includes('404')
+          lowerMessage.includes('404')
         ) {
           errorMessage =
             'No orders available for this trade. Try a different amount or rune.';
         } else if (
-          errorMessage.includes('500') ||
+          lowerMessage.includes('500') ||
           lowerMessage.includes('internal server error')
         ) {
           errorMessage =

--- a/src/lib/api/createApiClient.ts
+++ b/src/lib/api/createApiClient.ts
@@ -57,7 +57,11 @@ async function makeApiCall<T>(
       throw new Error(errorMessage);
     }
 
-    return response.data.data as T;
+    if (response.data.data === undefined || response.data.data === null) {
+      throw new Error('API returned success but no data');
+    }
+
+    return response.data.data;
   } catch (error: unknown) {
     logFetchError(url, error);
     throw error;

--- a/src/lib/api/createApiClient.ts
+++ b/src/lib/api/createApiClient.ts
@@ -3,7 +3,8 @@ import { logFetchError } from '@/lib/logger';
 
 type ApiResponse<T> = {
   success: boolean;
-  data: T;
+  data?: T;
+  error?: { message?: string; details?: string; code?: string };
 };
 
 /**
@@ -49,10 +50,14 @@ async function makeApiCall<T>(
         : await post<ApiResponse<T>>(endpoint, body);
 
     if (!response.data.success) {
-      throw new Error('API request failed');
+      const errorMessage =
+        response.data.error?.message ??
+        response.data.error?.details ??
+        'API request failed';
+      throw new Error(errorMessage);
     }
 
-    return response.data.data;
+    return response.data.data as T;
   } catch (error: unknown) {
     logFetchError(url, error);
     throw error;


### PR DESCRIPTION
## Summary
- map SatsTerminal quote errors (no orders/liquidity) to 404s consistently
- surface friendly quote error messages in the swap UI
- include API error payload message when response.success is false

## Testing
- pre-push hook: pnpm exec eslint --fix, pnpm exec prettier --write, pnpm exec tsc --noEmit, pnpm exec jest --runInBand, next build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented UI crashes when swap quotes fail by mapping various order/liquidity errors to friendly messages and clearing stale quote data.
  * Improved detection and messaging for liquidity, rate-limit, timeout, and unavailable-API scenarios.
  * API client now throws when a success response lacks expected data.

* **Chores**
  * Release bumped to v0.2.8 and CHANGELOG updated with the v0.2.8 entry and comparison link.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->