### PR TITLE
ci: add automatic PR reviews to opencode workflow

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -5,6 +5,8 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   opencode:
@@ -31,3 +33,29 @@ jobs:
           KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
         with:
           model: kimi-for-coding/k3
+
+  review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Review pull request
+        uses: anomalyco/opencode/github@latest
+        env:
+          KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}
+        with:
+          model: kimi-for-coding/k3
+          prompt: |
+            Review this pull request:
+            - Check for code quality issues
+            - Look for potential bugs
+            - Suggest improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ## [Unreleased]
 
 ### Added
+- Automatic PR reviews in the opencode workflow (runs on PR open/update, reviews with Kimi k3).
 - Add opencode GitHub workflow for automated PR reviews and `/oc` commands (Kimi k3).
 - Centralized QueryClient defaults and query key factories.
 - CI workflows: PR (type-check, lint, test) and main build.
@@ -264,5 +265,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.0]: https://github.com/ropl-btc/RunesSwap.app/releases/tag/v0.1.0
 [0.2.5]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.4...v0.2.5
 [0.2.6]: https://github.com/ropl-btc/RunesSwap.app/compare/v0.2.5...v0.2.6
+
 
 


### PR DESCRIPTION
Adds a review job to opencode.yml triggered on PR open/sync/reopen/ready_for_review (per opencode docs pull_request example). Comment-triggered /oc behavior unchanged.